### PR TITLE
Require the app to provide a fallback destination uri

### DIFF
--- a/turbolinks/src/main/kotlin/com/basecamp/turbolinks/TurbolinksRouter.kt
+++ b/turbolinks/src/main/kotlin/com/basecamp/turbolinks/TurbolinksRouter.kt
@@ -1,5 +1,6 @@
 package com.basecamp.turbolinks
 
+import android.net.Uri
 import androidx.navigation.NavOptions
 
 abstract class TurbolinksRouter {
@@ -12,6 +13,8 @@ abstract class TurbolinksRouter {
                                       newLocation: String,
                                       currentPathProperties: PathProperties,
                                       newPathProperties: PathProperties): NavOptions?
+
+    abstract fun getFallbackDeepLinkUri(location: String): Uri
 }
 
 enum class PresentationContext {

--- a/turbolinks/src/main/kotlin/com/basecamp/turbolinks/TurbolinksSession.kt
+++ b/turbolinks/src/main/kotlin/com/basecamp/turbolinks/TurbolinksSession.kt
@@ -265,7 +265,7 @@ class TurbolinksSession private constructor(val sessionName: String, val context
     }
 
     private fun installBridge(location: String) {
-        logEvent("installBridge")
+        logEvent("installBridge", "location" to location)
 
         webView.installBridge {
             callback { it.onPageFinished(location) }


### PR DESCRIPTION
Require the app to provide a fallback destination deep-link-uri if a destination associated with the `uri` in the path configuration is not found in the navigation graph.