### PR TITLE
Don't double-encode urls

### DIFF
--- a/turbolinks/src/main/kotlin/com/basecamp/turbolinks/TurbolinksExtensions.kt
+++ b/turbolinks/src/main/kotlin/com/basecamp/turbolinks/TurbolinksExtensions.kt
@@ -46,16 +46,6 @@ internal fun <T> String.toObject(typeToken: TypeToken<T>): T {
     return gson().fromJson<T>(this, typeToken.type)
 }
 
-internal fun String.urlEncode(): String {
-    return try {
-        val url = URL(this)
-        val uri = URI(url.protocol, url.userInfo, url.host, url.port, url.path, url.query, url.ref)
-        uri.toURL().toString()
-    } catch (e: Exception) {
-        ""
-    }
-}
-
 internal fun View.visible() {
     visibility = View.VISIBLE
 }

--- a/turbolinks/src/main/kotlin/com/basecamp/turbolinks/TurbolinksWebView.kt
+++ b/turbolinks/src/main/kotlin/com/basecamp/turbolinks/TurbolinksWebView.kt
@@ -29,7 +29,7 @@ open class TurbolinksWebView @JvmOverloads constructor(context: Context, attrs: 
         get() = versionName?.substringBefore(".")?.toIntOrNull()
 
     internal fun visitLocation(location: String, options: VisitOptions, restorationIdentifier: String) {
-        val args = encodeArguments(location.urlEncode(), options.toJson(), restorationIdentifier)
+        val args = encodeArguments(location, options.toJson(), restorationIdentifier)
         runJavascript("webView.visitLocationWithOptionsAndRestorationIdentifier($args)")
     }
 

--- a/turbolinks/src/test/kotlin/com/basecamp/turbolinks/TurbolinksSessionTest.kt
+++ b/turbolinks/src/test/kotlin/com/basecamp/turbolinks/TurbolinksSessionTest.kt
@@ -124,11 +124,6 @@ class TurbolinksSessionTest {
             assertThat(domStorageEnabled).isTrue()
         }
     }
-
-    @Test fun encodeUrlProperlyEncodes() {
-        val url = "http://basecamp.com/search?q=test test + testing & /testfile .mp4"
-        assertThat(url.urlEncode()).doesNotContain(" ")
-    }
 }
 
 internal class TurbolinksTestActivity : Activity()


### PR DESCRIPTION
Don't encode urls to visit, due to double-encoding issues. Urls originating from the WebView will already be encoded. Urls originating from the app need to be manually encoded, such as a search query string.