### PR TITLE
Cache path configuration responses using the url as the key

### DIFF
--- a/turbolinks/src/main/kotlin/com/basecamp/turbolinks/PathConfigurationLoader.kt
+++ b/turbolinks/src/main/kotlin/com/basecamp/turbolinks/PathConfigurationLoader.kt
@@ -19,12 +19,12 @@ class PathConfigurationLoader(val context: Context) {
 
     private fun downloadRemoteConfiguration(url: String, onCompletion: (PathConfiguration) -> Unit) {
         // Always load the previously cached version first, if available
-        loadCachedConfiguration(onCompletion)
+        loadCachedConfigurationForUrl(url, onCompletion)
 
         context.coroutineScope().launch {
             repository.getRemoteConfiguration(url)?.let {
                 onCompletion(load(it))
-                cacheConfiguration(load(it))
+                cacheConfigurationForUrl(url, load(it))
             }
         }
     }
@@ -34,14 +34,14 @@ class PathConfigurationLoader(val context: Context) {
         onCompletion(load(configuration))
     }
 
-    private fun loadCachedConfiguration(onCompletion: (PathConfiguration) -> Unit) {
-        repository.getCachedConfiguration(context)?.let {
+    private fun loadCachedConfigurationForUrl(url: String, onCompletion: (PathConfiguration) -> Unit) {
+        repository.getCachedConfigurationForUrl(context, url)?.let {
             onCompletion(load(it))
         }
     }
 
-    private fun cacheConfiguration(pathConfiguration: PathConfiguration) {
-        repository.cacheConfiguration(context, pathConfiguration)
+    private fun cacheConfigurationForUrl(url: String, pathConfiguration: PathConfiguration) {
+        repository.cacheConfigurationForUrl(context, url, pathConfiguration)
     }
 
     private fun load(json: String): PathConfiguration {

--- a/turbolinks/src/main/kotlin/com/basecamp/turbolinks/PathConfigurationRepository.kt
+++ b/turbolinks/src/main/kotlin/com/basecamp/turbolinks/PathConfigurationRepository.kt
@@ -10,7 +10,6 @@ import java.io.IOException
 
 internal class PathConfigurationRepository {
     private val cacheFile = "turbolinks"
-    private val cacheKey = "configuration.json"
 
     suspend fun getRemoteConfiguration(url: String): String? {
         val request = Request.Builder().url(url).build()
@@ -24,13 +23,13 @@ internal class PathConfigurationRepository {
         return contentFromAsset(context, filePath)
     }
 
-    fun getCachedConfiguration(context: Context): String? {
-        return prefs(context).getString(cacheKey, null)
+    fun getCachedConfigurationForUrl(context: Context, url: String): String? {
+        return prefs(context).getString(url, null)
     }
 
-    fun cacheConfiguration(context: Context, pathConfiguration: PathConfiguration) {
+    fun cacheConfigurationForUrl(context: Context, url: String, pathConfiguration: PathConfiguration) {
         prefs(context).edit {
-            putString(cacheKey, pathConfiguration.toJson())
+            putString(url, pathConfiguration.toJson())
         }
     }
 


### PR DESCRIPTION
Cache path configuration responses using the url as the key, so breaking changes are not carried over when the remote configuration url changes