### PR TITLE
Prioritize modal context switching over Presentation.NONE

### DIFF
--- a/turbolinks/src/main/assets/json/test-configuration.json
+++ b/turbolinks/src/main/assets/json/test-configuration.json
@@ -42,6 +42,14 @@
       "properties": {
         "presentation": "refresh"
       }
+    },
+    {
+      "patterns": [
+        "/custom/resume"
+      ],
+      "properties": {
+        "presentation": "none"
+      }
     }
   ]
 }

--- a/turbolinks/src/main/kotlin/com/basecamp/turbolinks/TurbolinksNavigationRule.kt
+++ b/turbolinks/src/main/kotlin/com/basecamp/turbolinks/TurbolinksNavigationRule.kt
@@ -95,10 +95,10 @@ class TurbolinksNavigationRule(
             newPresentation != Presentation.REPLACE_ROOT
 
         return when {
-            presentationNone -> NavigationMode.NONE
-            presentationRefresh -> NavigationMode.REFRESH
             dismissModalContext -> NavigationMode.DISMISS_MODAL
             navigateToModalContext -> NavigationMode.TO_MODAL
+            presentationRefresh -> NavigationMode.REFRESH
+            presentationNone -> NavigationMode.NONE
             else -> NavigationMode.IN_CONTEXT
         }
     }

--- a/turbolinks/src/test/kotlin/com/basecamp/turbolinks/PathConfigurationRepositoryTest.kt
+++ b/turbolinks/src/test/kotlin/com/basecamp/turbolinks/PathConfigurationRepositoryTest.kt
@@ -48,7 +48,7 @@ class PathConfigurationRepositoryTest : BaseRepositoryTest() {
         assertThat(json).isNotNull()
 
         val config = load(json)
-        assertThat(config?.rules?.size).isEqualTo(5)
+        assertThat(config?.rules?.size).isEqualTo(6)
     }
 
     @Test

--- a/turbolinks/src/test/kotlin/com/basecamp/turbolinks/PathConfigurationTest.kt
+++ b/turbolinks/src/test/kotlin/com/basecamp/turbolinks/PathConfigurationTest.kt
@@ -32,7 +32,7 @@ class PathConfigurationTest {
 
     @Test
     fun assetConfigurationIsLoaded() {
-        assertThat(pathConfiguration.rules.size).isEqualTo(5)
+        assertThat(pathConfiguration.rules.size).isEqualTo(6)
     }
 
     @Test


### PR DESCRIPTION
Prioritize modal context switching over `Presentation.NONE`, since we need to dismiss a modal and send the modal result before using a `NONE` presentation for the previous destination.