### PR TITLE
Fix web fragment memory leak

### DIFF
--- a/turbolinks/src/main/kotlin/com/basecamp/turbolinks/TurbolinksSession.kt
+++ b/turbolinks/src/main/kotlin/com/basecamp/turbolinks/TurbolinksSession.kt
@@ -92,6 +92,11 @@ class TurbolinksSession private constructor(val sessionName: String, val activit
         }
     }
 
+    internal fun removeCallback(callback: TurbolinksSessionCallback) {
+        if (currentVisit.callback == callback) {
+            currentVisit.callback = null
+        }
+    }
 
     // Callbacks from Turbolinks Core
 
@@ -307,8 +312,8 @@ class TurbolinksSession private constructor(val sessionName: String, val activit
 
     private fun callback(action: (TurbolinksSessionCallback) -> Unit) {
         context.runOnUiThread {
-            if (currentVisit.callback.isActive()) {
-                action(currentVisit.callback)
+            currentVisit.callback?.let {
+                if (it.isActive()) action(it)
             }
         }
     }

--- a/turbolinks/src/main/kotlin/com/basecamp/turbolinks/TurbolinksVisit.kt
+++ b/turbolinks/src/main/kotlin/com/basecamp/turbolinks/TurbolinksVisit.kt
@@ -5,7 +5,7 @@ data class TurbolinksVisit(
     val destinationIdentifier: Int,
     val restoreWithCachedSnapshot: Boolean,
     val reload: Boolean,
-    val callback: TurbolinksSessionCallback,
+    var callback: TurbolinksSessionCallback?,   // Available while current visit
     var identifier: String = "",                // Updated after visitStarted()
     var completedOffline: Boolean = false,      // Updated from shouldInterceptRequest()
     val options: VisitOptions

--- a/turbolinks/src/main/kotlin/com/basecamp/turbolinks/TurbolinksWebFragmentDelegate.kt
+++ b/turbolinks/src/main/kotlin/com/basecamp/turbolinks/TurbolinksWebFragmentDelegate.kt
@@ -36,6 +36,7 @@ class TurbolinksWebFragmentDelegate(private val destination: TurbolinksDestinati
 
         navigator.onNavigationVisit = { onReady ->
             destination.onBeforeNavigation()
+            session().removeCallback(this)
             detachWebView(onReady)
         }
     }


### PR DESCRIPTION
Remove the fragment callback reference from the session before navigating, so we don't leak the web fragment.