### PR TITLE
Prevent a blank WebView by quickly double-launching a bottom sheet dialog

### DIFF
--- a/turbolinks/src/main/kotlin/com/basecamp/turbolinks/TurbolinksView.kt
+++ b/turbolinks/src/main/kotlin/com/basecamp/turbolinks/TurbolinksView.kt
@@ -9,6 +9,7 @@ import android.view.ViewGroup
 import android.webkit.WebView
 import android.widget.FrameLayout
 import android.widget.ImageView
+import androidx.core.view.contains
 import androidx.core.view.drawToBitmap
 import androidx.core.view.isVisible
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
@@ -54,6 +55,10 @@ class TurbolinksView @JvmOverloads constructor(context: Context, attrs: Attribut
                 onDetached()
             }
         }
+    }
+
+    internal fun webViewIsAttached(webView: WebView): Boolean {
+        return webViewContainer.contains(webView)
     }
 
     internal fun addProgressView(progressView: View) {

--- a/turbolinks/src/main/kotlin/com/basecamp/turbolinks/TurbolinksWebBottomSheetDialogFragment.kt
+++ b/turbolinks/src/main/kotlin/com/basecamp/turbolinks/TurbolinksWebBottomSheetDialogFragment.kt
@@ -28,6 +28,11 @@ abstract class TurbolinksWebBottomSheetDialogFragment : TurbolinksBottomSheetDia
         super.onCancel(dialog)
     }
 
+    override fun onDismiss(dialog: DialogInterface) {
+        delegate.onDialogDismiss()
+        super.onDismiss(dialog)
+    }
+
     override fun onBeforeNavigation() {
         // Allow subclasses to do state cleanup
     }

--- a/turbolinks/src/main/kotlin/com/basecamp/turbolinks/TurbolinksWebFragmentDelegate.kt
+++ b/turbolinks/src/main/kotlin/com/basecamp/turbolinks/TurbolinksWebFragmentDelegate.kt
@@ -59,6 +59,14 @@ class TurbolinksWebFragmentDelegate(private val destination: TurbolinksDestinati
         detachWebView()
     }
 
+    fun onDialogDismiss() {
+        // The WebView is already detached in most circumstances, but sometimes
+        // fast user cancellation does not call onCancel() before onDismiss()
+        if (webViewIsAttached()) {
+            detachWebView()
+        }
+    }
+
     fun session(): TurbolinksSession {
         return destination.session
     }
@@ -210,6 +218,11 @@ class TurbolinksWebFragmentDelegate(private val destination: TurbolinksDestinati
                 isInitialVisit = false
             }
         }
+    }
+
+    private fun webViewIsAttached(): Boolean {
+        val view = webView ?: return false
+        return turbolinksView?.webViewIsAttached(view) ?: false
     }
 
     private fun title(): String {


### PR DESCRIPTION
Normally, a user cancellation (tapping the outside overlay) of a bottom sheet calls `onCancel()` -> `onDismiss()`.

This works around (seemingly) a bug in the `DialogFragment` lifecycle, where opening and (very quickly) cancelling a bottom sheet only calls `onDismiss()` (and `onCancel()` is never called).