### PR TITLE
Cancel dialogs properly when dismissing from toolbar navigation

### DIFF
--- a/turbolinks/src/main/kotlin/com/basecamp/turbolinks/TurbolinksBottomSheetDialogFragment.kt
+++ b/turbolinks/src/main/kotlin/com/basecamp/turbolinks/TurbolinksBottomSheetDialogFragment.kt
@@ -32,6 +32,11 @@ abstract class TurbolinksBottomSheetDialogFragment : BottomSheetDialogFragment()
         super.onCancel(dialog)
     }
 
+    override fun onDismiss(dialog: DialogInterface) {
+        delegate.onDialogDismiss()
+        super.onDismiss(dialog)
+    }
+
     override fun onBeforeNavigation() {
         // Allow subclasses to do state cleanup
     }

--- a/turbolinks/src/main/kotlin/com/basecamp/turbolinks/TurbolinksFragmentDelegate.kt
+++ b/turbolinks/src/main/kotlin/com/basecamp/turbolinks/TurbolinksFragmentDelegate.kt
@@ -1,5 +1,6 @@
 package com.basecamp.turbolinks
 
+import androidx.fragment.app.DialogFragment
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.ui.NavigationUI
 
@@ -46,6 +47,10 @@ class TurbolinksFragmentDelegate(private val destination: TurbolinksDestination)
         }
     }
 
+    fun onDialogDismiss() {
+        logEvent("fragment.onDialogDismiss", "location" to location)
+    }
+
     // ----------------------------------------------------------------------------
     // Private
     // ----------------------------------------------------------------------------
@@ -53,7 +58,12 @@ class TurbolinksFragmentDelegate(private val destination: TurbolinksDestination)
     private fun initToolbar() {
         destination.toolbarForNavigation()?.let {
             NavigationUI.setupWithNavController(it, fragment.findNavController())
-            it.setNavigationOnClickListener { destination.navigateUp() }
+            it.setNavigationOnClickListener {
+                when (fragment) {
+                    is DialogFragment -> fragment.requireDialog().cancel()
+                    else -> destination.navigateUp()
+                }
+            }
         }
     }
 


### PR DESCRIPTION
If a toolbar navigation arrow/icon is provided on a bottom sheet, force it to cancel the dialog so the proper lifecycle callbacks are called