### PR TITLE
Out-of-the-box support for file uploads

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,4 +17,4 @@ jobs:
         if: failure()
         with:
           name: test-results-report
-          path: build/reports/tests/testReleaseUnitTest
+          path: turbo/build/reports/tests/testReleaseUnitTest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,3 +11,9 @@ jobs:
 
       - name: Run tests
         run: ./gradlew testRelease
+
+      - name: Archive test results
+        uses: actions/upload-artifact@v2
+        with:
+          name: test-results-report
+          path: build/reports/tests/testReleaseUnitTest/*.html

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,7 @@ jobs:
 
       - name: Archive test results
         uses: actions/upload-artifact@v2
+        if: failure()
         with:
           name: test-results-report
           path: build/reports/tests/testReleaseUnitTest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,4 +16,4 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: test-results-report
-          path: build/reports/tests/testReleaseUnitTest/*.html
+          path: build/reports/tests/testReleaseUnitTest

--- a/turbo/build.gradle
+++ b/turbo/build.gradle
@@ -34,6 +34,7 @@ buildscript {
 repositories {
     google()
     mavenCentral()
+    jcenter()
 }
 
 android {

--- a/turbo/src/main/AndroidManifest.xml
+++ b/turbo/src/main/AndroidManifest.xml
@@ -1,3 +1,19 @@
-<manifest package="dev.hotwire.turbo">
-    <application/>
+<manifest
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    package="dev.hotwire.turbo">
+
+    <application>
+
+        <provider
+            android:name=".util.TurboFileProvider"
+            android:authorities="${applicationId}.turbo.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_provider_paths" />
+        </provider>
+
+    </application>
+
 </manifest>

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/config/TurboPathConfigurationRepository.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/config/TurboPathConfigurationRepository.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.SharedPreferences
 import androidx.core.content.edit
 import dev.hotwire.turbo.http.TurboHttpClient
+import dev.hotwire.turbo.util.dispatcherProvider
 import dev.hotwire.turbo.util.toJson
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -16,7 +17,7 @@ internal class TurboPathConfigurationRepository {
     suspend fun getRemoteConfiguration(url: String): String? {
         val request = Request.Builder().url(url).build()
 
-        return withContext(Dispatchers.IO) {
+        return withContext(dispatcherProvider.io) {
             issueRequest(request)
         }
     }

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/delegates/TurboFileUploadDelegate.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/delegates/TurboFileUploadDelegate.kt
@@ -111,8 +111,6 @@ internal class TurboFileUploadDelegate(val session: TurboSession) : CoroutineSco
             }
         }
 
-        // TODO allow read/write failure to be observed
-
         return when {
             arrayList.isEmpty() -> null
             else -> arrayList.toTypedArray()
@@ -121,9 +119,6 @@ internal class TurboFileUploadDelegate(val session: TurboSession) : CoroutineSco
 
     private suspend fun buildSingleFileResult(dataString: String): Array<Uri>? {
         val uri = writeToCachedFile(Uri.parse(dataString))
-
-        // TODO allow read/write failure to be observed
-
         return uri?.let { arrayOf(it) }
     }
 

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/delegates/TurboFileUploadDelegate.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/delegates/TurboFileUploadDelegate.kt
@@ -9,6 +9,7 @@ import android.webkit.ValueCallback
 import android.webkit.WebChromeClient.FileChooserParams
 import dev.hotwire.turbo.session.TurboSession
 import dev.hotwire.turbo.util.TurboFileProvider
+import dev.hotwire.turbo.util.dispatcherProvider
 import kotlinx.coroutines.*
 import kotlin.coroutines.CoroutineContext
 
@@ -18,10 +19,8 @@ internal class TurboFileUploadDelegate(val session: TurboSession) : CoroutineSco
     private val context: Context = session.context
     private var uploadCallback: ValueCallback<Array<Uri>>? = null
 
-    var coroutineDispatcher: CoroutineDispatcher = Dispatchers.IO
-
     override val coroutineContext: CoroutineContext
-        get() = coroutineDispatcher + Job()
+        get() = dispatcherProvider.io + Job()
 
     fun onShowFileChooser(
         filePathCallback: ValueCallback<Array<Uri>>,

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/delegates/TurboFileUploadDelegate.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/delegates/TurboFileUploadDelegate.kt
@@ -1,0 +1,105 @@
+package dev.hotwire.turbo.delegates
+
+import android.app.Activity
+import android.content.ClipData
+import android.content.Intent
+import android.net.Uri
+import android.webkit.ValueCallback
+import android.webkit.WebChromeClient.FileChooserParams
+import dev.hotwire.turbo.nav.TurboNavDestination
+import dev.hotwire.turbo.session.TurboSession
+
+const val TURBO_REQUEST_CODE_FILES = 37
+
+class TurboFileUploadDelegate(val session: TurboSession) {
+    private var uploadCallback: ValueCallback<Array<Uri>>? = null
+
+    fun onShowFileChooser(
+        filePathCallback: ValueCallback<Array<Uri>>,
+        params: FileChooserParams,
+        destination: TurboNavDestination
+    ): Boolean {
+        uploadCallback = filePathCallback
+        openFileChooser(params, destination)
+        return true
+    }
+
+    fun onActivityResult(requestCode: Int, resultCode: Int, intent: Intent?) {
+        handleActivityResult(requestCode, resultCode, intent)
+    }
+
+    private fun openFileChooser(params: FileChooserParams, destination: TurboNavDestination) {
+        val allowMultiple = params.mode == FileChooserParams.MODE_OPEN_MULTIPLE
+
+        val fileTypesIntent = Intent(Intent.ACTION_GET_CONTENT).apply {
+            addCategory(Intent.CATEGORY_OPENABLE)
+            putExtra(Intent.EXTRA_ALLOW_MULTIPLE, allowMultiple)
+
+            if (params.acceptTypes.size > 1) {
+                putExtra(Intent.EXTRA_MIME_TYPES, params.acceptTypes)
+            }
+
+            type = when {
+                params.acceptTypes.isEmpty() -> "*/*"
+                params.acceptTypes.first().isBlank() -> "*/*"
+                else -> params.acceptTypes.first()
+            }
+        }
+
+        val title = params.title ?: when (allowMultiple) {
+            true -> "Choose Files"
+            else -> "Choose File"
+        }
+
+        val chooserIntent = Intent.createChooser(fileTypesIntent, title)
+        destination.fragment.startActivityForResult(chooserIntent, TURBO_REQUEST_CODE_FILES)
+    }
+
+    private fun handleActivityResult(requestCode: Int, resultCode: Int, intent: Intent?) {
+        if (requestCode != TURBO_REQUEST_CODE_FILES) return
+
+        when (resultCode) {
+            Activity.RESULT_CANCELED -> handleFileCancellation()
+            Activity.RESULT_OK -> handleFileSelection(intent)
+        }
+    }
+
+    private fun handleFileCancellation() {
+        // Important to send a null value to the upload callback, otherwise the webview
+        // gets into a state where it doesn't allow the file chooser to open again.
+        uploadCallback?.onReceiveValue(null)
+        uploadCallback = null
+    }
+
+    private fun handleFileSelection(intent: Intent?) {
+        if (intent == null) return
+
+        val clipData = intent.clipData
+        val dataString = intent.dataString
+        val results = when {
+            clipData != null -> buildMultipleFilesResult(clipData)
+            dataString != null -> buildSingleFileResult(dataString)
+            else -> null
+        }
+
+        uploadCallback?.onReceiveValue(results)
+        uploadCallback = null
+    }
+
+    private fun buildMultipleFilesResult(clipData: ClipData): Array<Uri>? {
+        val arrayList = mutableListOf<Uri>()
+
+        for (i in 0 until clipData.itemCount) {
+            arrayList.add(clipData.getItemAt(i).uri)
+        }
+
+        return when {
+            arrayList.isEmpty() -> null
+            else -> arrayList.toTypedArray()
+        }
+    }
+
+    private fun buildSingleFileResult(dataString: String): Array<Uri> {
+        return arrayOf(Uri.parse(dataString))
+    }
+}

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/delegates/TurboFileUploadDelegate.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/delegates/TurboFileUploadDelegate.kt
@@ -7,7 +7,6 @@ import android.content.Intent
 import android.net.Uri
 import android.webkit.ValueCallback
 import android.webkit.WebChromeClient.FileChooserParams
-import dev.hotwire.turbo.nav.TurboNavDestination
 import dev.hotwire.turbo.session.TurboSession
 import dev.hotwire.turbo.util.TurboFileProvider
 import kotlinx.coroutines.CoroutineScope
@@ -27,19 +26,18 @@ internal class TurboFileUploadDelegate(val session: TurboSession) : CoroutineSco
 
     fun onShowFileChooser(
         filePathCallback: ValueCallback<Array<Uri>>,
-        params: FileChooserParams,
-        destination: TurboNavDestination
+        params: FileChooserParams
     ): Boolean {
         uploadCallback = filePathCallback
-        openFileChooser(params, destination)
-        return true
+        return openFileChooser(params)
     }
 
     fun onActivityResult(requestCode: Int, resultCode: Int, intent: Intent?) {
         handleActivityResult(requestCode, resultCode, intent)
     }
 
-    private fun openFileChooser(params: FileChooserParams, destination: TurboNavDestination) {
+    private fun openFileChooser(params: FileChooserParams): Boolean {
+        val destination = session.currentVisitNavDestination ?: return false
         val allowMultiple = params.mode == FileChooserParams.MODE_OPEN_MULTIPLE
 
         val fileTypesIntent = Intent(Intent.ACTION_GET_CONTENT).apply {
@@ -64,6 +62,7 @@ internal class TurboFileUploadDelegate(val session: TurboSession) : CoroutineSco
 
         val chooserIntent = Intent.createChooser(fileTypesIntent, title)
         destination.fragment.startActivityForResult(chooserIntent, TURBO_REQUEST_CODE_FILES)
+        return true
     }
 
     private fun handleActivityResult(requestCode: Int, resultCode: Int, intent: Intent?) {

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/delegates/TurboFileUploadDelegate.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/delegates/TurboFileUploadDelegate.kt
@@ -9,10 +9,7 @@ import android.webkit.ValueCallback
 import android.webkit.WebChromeClient.FileChooserParams
 import dev.hotwire.turbo.session.TurboSession
 import dev.hotwire.turbo.util.TurboFileProvider
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.*
 import kotlin.coroutines.CoroutineContext
 
 const val TURBO_REQUEST_CODE_FILES = 37
@@ -21,8 +18,10 @@ internal class TurboFileUploadDelegate(val session: TurboSession) : CoroutineSco
     private val context: Context = session.context
     private var uploadCallback: ValueCallback<Array<Uri>>? = null
 
+    var coroutineDispatcher: CoroutineDispatcher = Dispatchers.IO
+
     override val coroutineContext: CoroutineContext
-        get() = Dispatchers.IO + Job()
+        get() = coroutineDispatcher + Job()
 
     fun onShowFileChooser(
         filePathCallback: ValueCallback<Array<Uri>>,
@@ -34,6 +33,12 @@ internal class TurboFileUploadDelegate(val session: TurboSession) : CoroutineSco
 
     fun onActivityResult(requestCode: Int, resultCode: Int, intent: Intent?) {
         handleActivityResult(requestCode, resultCode, intent)
+    }
+
+    fun deleteCachedFiles() {
+        launch {
+            TurboFileProvider.deleteAllFiles(context)
+        }
     }
 
     private fun openFileChooser(params: FileChooserParams): Boolean {

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/delegates/TurboWebFragmentDelegate.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/delegates/TurboWebFragmentDelegate.kt
@@ -208,8 +208,8 @@ internal class TurboWebFragmentDelegate(
         navigator.navigate(location, options)
     }
 
-    override fun isActive(): Boolean {
-        return navDestination.fragment.isAdded
+    override fun visitNavDestination(): TurboNavDestination {
+        return navDestination
     }
 
     // -----------------------------------------------------------------------

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/delegates/TurboWebFragmentDelegate.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/delegates/TurboWebFragmentDelegate.kt
@@ -11,6 +11,7 @@ import dev.hotwire.turbo.nav.TurboNavigator
 import dev.hotwire.turbo.session.TurboSession
 import dev.hotwire.turbo.session.TurboSessionCallback
 import dev.hotwire.turbo.session.TurboSessionModalResult
+import dev.hotwire.turbo.util.dispatcherProvider
 import dev.hotwire.turbo.views.TurboView
 import dev.hotwire.turbo.views.TurboWebView
 import dev.hotwire.turbo.visit.TurboVisit
@@ -326,7 +327,7 @@ internal class TurboWebFragmentDelegate(
     }
 
     private suspend fun fetchCachedSnapshot(): String? {
-        return withContext(Dispatchers.IO) {
+        return withContext(dispatcherProvider.io) {
             val response = session().offlineRequestHandler?.getCachedSnapshot(
                 url = location
             )

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/delegates/TurboWebFragmentDelegate.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/delegates/TurboWebFragmentDelegate.kt
@@ -1,5 +1,6 @@
 package dev.hotwire.turbo.delegates
 
+import android.content.Intent
 import android.graphics.Bitmap
 import android.webkit.HttpAuthHandler
 import androidx.lifecycle.lifecycleScope
@@ -68,10 +69,19 @@ internal class TurboWebFragmentDelegate(
 
     /**
      * Should be called by the implementing Fragment during
+     * [androidx.fragment.app.Fragment.onActivityResult].
+     */
+    fun onActivityResult(requestCode: Int, resultCode: Int, intent: Intent?) {
+        session().fileUploadDelegate.onActivityResult(requestCode, resultCode, intent)
+    }
+
+    /**
+     * Should be called by the implementing Fragment during
      * [androidx.fragment.app.Fragment.onStart].
      */
     fun onStart() {
         initNavigationVisit()
+        initWebChromeClient()
     }
 
     /**
@@ -91,6 +101,7 @@ internal class TurboWebFragmentDelegate(
      */
     fun onStartAfterDialogCancel() {
         initNavigationVisit()
+        initWebChromeClient()
     }
 
     /**
@@ -225,6 +236,10 @@ internal class TurboWebFragmentDelegate(
             screenshotOrientation = 0
             screenshotZoomed = false
         }
+    }
+
+    private fun initWebChromeClient() {
+        webView.webChromeClient = callback.createWebChromeClient()
     }
 
     private fun attachWebView(onReady: (Boolean) -> Unit = {}) {

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/fragments/TurboWebBottomSheetDialogFragment.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/fragments/TurboWebBottomSheetDialogFragment.kt
@@ -2,6 +2,7 @@ package dev.hotwire.turbo.fragments
 
 import android.annotation.SuppressLint
 import android.content.DialogInterface
+import android.content.Intent
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -9,6 +10,7 @@ import android.view.ViewGroup
 import dev.hotwire.turbo.R
 import dev.hotwire.turbo.delegates.TurboWebFragmentDelegate
 import dev.hotwire.turbo.views.TurboView
+import dev.hotwire.turbo.views.TurboWebChromeClient
 
 /**
  * The base class from which all bottom sheet web fragments in a
@@ -33,6 +35,10 @@ abstract class TurboWebBottomSheetDialogFragment : TurboBottomSheetDialogFragmen
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
         webDelegate.onActivityCreated()
+    }
+
+    override fun onActivityResult(requestCode: Int, resultCode: Int, intent: Intent?) {
+        webDelegate.onActivityResult(requestCode, resultCode, intent)
     }
 
     override fun onStart() {
@@ -69,6 +75,10 @@ abstract class TurboWebBottomSheetDialogFragment : TurboBottomSheetDialogFragmen
     @SuppressLint("InflateParams")
     override fun createErrorView(statusCode: Int): View {
         return layoutInflater.inflate(R.layout.turbo_error, null)
+    }
+
+    override fun createWebChromeClient(): TurboWebChromeClient {
+        return TurboWebChromeClient(this)
     }
 
     override fun onVisitErrorReceived(location: String, errorCode: Int) {

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/fragments/TurboWebBottomSheetDialogFragment.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/fragments/TurboWebBottomSheetDialogFragment.kt
@@ -78,7 +78,7 @@ abstract class TurboWebBottomSheetDialogFragment : TurboBottomSheetDialogFragmen
     }
 
     override fun createWebChromeClient(): TurboWebChromeClient {
-        return TurboWebChromeClient(this)
+        return TurboWebChromeClient(session)
     }
 
     override fun onVisitErrorReceived(location: String, errorCode: Int) {

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/fragments/TurboWebFragment.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/fragments/TurboWebFragment.kt
@@ -90,7 +90,7 @@ abstract class TurboWebFragment : TurboFragment(), TurboWebFragmentCallback {
     }
 
     override fun createWebChromeClient(): TurboWebChromeClient {
-        return TurboWebChromeClient(this)
+        return TurboWebChromeClient(session)
     }
 
     override fun onVisitErrorReceived(location: String, errorCode: Int) {

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/fragments/TurboWebFragment.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/fragments/TurboWebFragment.kt
@@ -1,6 +1,7 @@
 package dev.hotwire.turbo.fragments
 
 import android.annotation.SuppressLint
+import android.content.Intent
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -9,6 +10,7 @@ import dev.hotwire.turbo.R
 import dev.hotwire.turbo.delegates.TurboWebFragmentDelegate
 import dev.hotwire.turbo.session.TurboSessionModalResult
 import dev.hotwire.turbo.views.TurboView
+import dev.hotwire.turbo.views.TurboWebChromeClient
 
 /**
  * The base class from which all web "standard" fragments (non-dialogs) in a
@@ -31,6 +33,10 @@ abstract class TurboWebFragment : TurboFragment(), TurboWebFragmentCallback {
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
         webDelegate.onActivityCreated()
+    }
+
+    override fun onActivityResult(requestCode: Int, resultCode: Int, intent: Intent?) {
+        webDelegate.onActivityResult(requestCode, resultCode, intent)
     }
 
     override fun onStart() {
@@ -81,6 +87,10 @@ abstract class TurboWebFragment : TurboFragment(), TurboWebFragmentCallback {
     @SuppressLint("InflateParams")
     override fun createErrorView(statusCode: Int): View {
         return layoutInflater.inflate(R.layout.turbo_error, null)
+    }
+
+    override fun createWebChromeClient(): TurboWebChromeClient {
+        return TurboWebChromeClient(this)
     }
 
     override fun onVisitErrorReceived(location: String, errorCode: Int) {

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/fragments/TurboWebFragmentCallback.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/fragments/TurboWebFragmentCallback.kt
@@ -3,6 +3,7 @@ package dev.hotwire.turbo.fragments
 import android.view.View
 import android.webkit.HttpAuthHandler
 import dev.hotwire.turbo.views.TurboView
+import dev.hotwire.turbo.views.TurboWebChromeClient
 import dev.hotwire.turbo.views.TurboWebView
 
 /**
@@ -24,6 +25,11 @@ interface TurboWebFragmentCallback {
      * Inflate and return a new view to serve as a progress view.
      */
     fun createProgressView(location: String): View
+
+    /**
+     * Create and return a new web chrome client instance.
+     */
+    fun createWebChromeClient(): TurboWebChromeClient
 
     /**
      * Called when the WebView has been attached to the current destination.

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/http/TurboHttpRepository.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/http/TurboHttpRepository.kt
@@ -5,6 +5,7 @@ import android.webkit.WebResourceRequest
 import android.webkit.WebResourceResponse
 import androidx.annotation.experimental.Experimental
 import dev.hotwire.turbo.util.TurboLog
+import dev.hotwire.turbo.util.dispatcherProvider
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import okhttp3.CacheControl
@@ -27,7 +28,7 @@ internal class TurboHttpRepository {
 
     internal suspend fun preCache(requestHandler: TurboOfflineRequestHandler,
                                   resourceRequest: WebResourceRequest) {
-        withContext(Dispatchers.IO) {
+        withContext(dispatcherProvider.io) {
             fetch(requestHandler, resourceRequest)
         }
     }

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/nav/TurboNavDestination.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/nav/TurboNavDestination.kt
@@ -14,10 +14,10 @@ import dev.hotwire.turbo.R
 import dev.hotwire.turbo.config.TurboPathConfiguration
 import dev.hotwire.turbo.config.TurboPathConfigurationProperties
 import dev.hotwire.turbo.delegates.TurboFragmentDelegate
+import dev.hotwire.turbo.delegates.TurboNestedFragmentDelegate
 import dev.hotwire.turbo.fragments.TurboFragmentViewModel
 import dev.hotwire.turbo.session.TurboSession
 import dev.hotwire.turbo.session.TurboSessionNavHostFragment
-import dev.hotwire.turbo.delegates.TurboNestedFragmentDelegate
 import dev.hotwire.turbo.visit.TurboVisitOptions
 
 /**
@@ -67,6 +67,13 @@ interface TurboNavDestination {
      */
     val fragmentViewModel: TurboFragmentViewModel
         get() = delegate().fragmentViewModel
+
+    /**
+     * Specifies whether the destination fragment is currently active and
+     * added to its parent activity.
+     */
+    val isActive: Boolean
+        get() = fragment.isAdded && !fragment.isDetached
 
     /**
      * Gets the delegate instance that handles the Fragment's lifecycle events.

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/session/TurboSession.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/session/TurboSession.kt
@@ -46,13 +46,13 @@ class TurboSession internal constructor(
     internal var currentVisit: TurboVisit? = null
     internal var coldBootVisitIdentifier = ""
     internal var previousOverrideUrlTime = 0L
+    internal var isColdBooting = false
     internal var visitPending = false
     internal var isRenderProcessGone = false
     internal var restorationIdentifiers = SparseArray<String>()
+    internal val context: Context = activity.applicationContext
     internal val httpRepository = TurboHttpRepository()
     internal val fileUploadDelegate = TurboFileUploadDelegate(this)
-    internal val context: Context = activity.applicationContext
-    internal var isColdBooting = false
 
     // User accessible
 

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/session/TurboSession.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/session/TurboSession.kt
@@ -89,6 +89,7 @@ class TurboSession internal constructor(
     init {
         initializeWebView()
         TurboHttpClient.enableCachingWith(context)
+        fileUploadDelegate.deleteCachedFiles()
     }
 
     // Public

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/session/TurboSession.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/session/TurboSession.kt
@@ -75,7 +75,7 @@ class TurboSession internal constructor(
         internal set
 
     /**
-     * Gets the nav destination that corresponds to the current visit.
+     * Gets the nav destination that corresponds to the current WebView visit.
      */
     val currentVisitNavDestination: TurboNavDestination?
         get() = currentVisit?.callback?.visitNavDestination()

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/session/TurboSession.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/session/TurboSession.kt
@@ -15,14 +15,11 @@ import androidx.webkit.WebViewCompat
 import androidx.webkit.WebViewFeature.*
 import dev.hotwire.turbo.config.TurboPathConfiguration
 import dev.hotwire.turbo.config.screenshotsEnabled
+import dev.hotwire.turbo.delegates.TurboFileUploadDelegate
 import dev.hotwire.turbo.http.TurboHttpClient
 import dev.hotwire.turbo.http.TurboHttpRepository
 import dev.hotwire.turbo.http.TurboOfflineRequestHandler
 import dev.hotwire.turbo.http.TurboPreCacheRequest
-import dev.hotwire.turbo.util.TurboLog
-import dev.hotwire.turbo.util.coroutineScope
-import dev.hotwire.turbo.util.runOnUiThread
-import dev.hotwire.turbo.util.toJson
 import dev.hotwire.turbo.util.*
 import dev.hotwire.turbo.views.TurboWebView
 import dev.hotwire.turbo.visit.TurboVisit
@@ -53,6 +50,7 @@ class TurboSession internal constructor(
     internal var isRenderProcessGone = false
     internal var restorationIdentifiers = SparseArray<String>()
     internal val httpRepository = TurboHttpRepository()
+    internal val fileUploadDelegate = TurboFileUploadDelegate(this)
     internal val context: Context = activity.applicationContext
     internal var isColdBooting = false
 

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/session/TurboSession.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/session/TurboSession.kt
@@ -20,6 +20,7 @@ import dev.hotwire.turbo.http.TurboHttpClient
 import dev.hotwire.turbo.http.TurboHttpRepository
 import dev.hotwire.turbo.http.TurboOfflineRequestHandler
 import dev.hotwire.turbo.http.TurboPreCacheRequest
+import dev.hotwire.turbo.nav.TurboNavDestination
 import dev.hotwire.turbo.util.*
 import dev.hotwire.turbo.views.TurboWebView
 import dev.hotwire.turbo.visit.TurboVisit
@@ -72,6 +73,12 @@ class TurboSession internal constructor(
      */
     var pathConfiguration = TurboPathConfiguration(context)
         internal set
+
+    /**
+     * Gets the nav destination that corresponds to the current visit.
+     */
+    val currentVisitNavDestination: TurboNavDestination?
+        get() = currentVisit?.callback?.visitNavDestination()
 
     /**
      * Provides the status of whether Turbo is initialized and ready for use.
@@ -489,8 +496,10 @@ class TurboSession internal constructor(
 
     private fun callback(action: (TurboSessionCallback) -> Unit) {
         context.runOnUiThread {
-            currentVisit?.callback?.let {
-                if (it.isActive()) action(it)
+            currentVisit?.callback?.let { callback ->
+                if (callback.visitNavDestination().isActive) {
+                    action(callback)
+                }
             }
         }
     }

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/session/TurboSessionCallback.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/session/TurboSessionCallback.kt
@@ -1,6 +1,7 @@
 package dev.hotwire.turbo.session
 
 import android.webkit.HttpAuthHandler
+import dev.hotwire.turbo.nav.TurboNavDestination
 import dev.hotwire.turbo.visit.TurboVisitOptions
 
 internal interface TurboSessionCallback {
@@ -17,5 +18,5 @@ internal interface TurboSessionCallback {
     fun visitCompleted(completedOffline: Boolean)
     fun visitLocationStarted(location: String)
     fun visitProposedToLocation(location: String, options: TurboVisitOptions)
-    fun isActive(): Boolean
+    fun visitNavDestination(): TurboNavDestination
 }

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/util/TurboDispatcherProvider.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/util/TurboDispatcherProvider.kt
@@ -1,0 +1,14 @@
+package dev.hotwire.turbo.util
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+
+data class TurboDispatcherProvider(
+    val main: CoroutineDispatcher,
+    var io: CoroutineDispatcher
+)
+
+val dispatcherProvider = TurboDispatcherProvider(
+    main = Dispatchers.Main,
+    io = Dispatchers.IO
+)

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/util/TurboDispatcherProvider.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/util/TurboDispatcherProvider.kt
@@ -3,12 +3,12 @@ package dev.hotwire.turbo.util
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 
-data class TurboDispatcherProvider(
+internal data class TurboDispatcherProvider(
     val main: CoroutineDispatcher,
     var io: CoroutineDispatcher
 )
 
-val dispatcherProvider = TurboDispatcherProvider(
+internal val dispatcherProvider = TurboDispatcherProvider(
     main = Dispatchers.Main,
     io = Dispatchers.IO
 )

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/util/TurboExtensions.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/util/TurboExtensions.kt
@@ -29,6 +29,11 @@ internal fun Context.coroutineScope(): CoroutineScope {
     return (this as? AppCompatActivity)?.lifecycleScope ?: GlobalScope
 }
 
+internal fun String.extract(patternRegex: String): String? {
+    val regex = Regex(patternRegex, RegexOption.IGNORE_CASE)
+    return regex.find(this)?.groups?.get(1)?.value
+}
+
 internal fun Any.toJson(): String {
     return gson.toJson(this)
 }

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/util/TurboExtensions.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/util/TurboExtensions.kt
@@ -11,6 +11,7 @@ import dev.hotwire.turbo.visit.TurboVisitAction
 import dev.hotwire.turbo.visit.TurboVisitActionAdapter
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.GlobalScope
+import java.io.File
 
 internal fun Context.runOnUiThread(func: () -> Unit) {
     when (mainLooper.isCurrentThread) {
@@ -32,6 +33,14 @@ internal fun Context.coroutineScope(): CoroutineScope {
 internal fun String.extract(patternRegex: String): String? {
     val regex = Regex(patternRegex, RegexOption.IGNORE_CASE)
     return regex.find(this)?.groups?.get(1)?.value
+}
+
+internal fun File.deleteAllFilesInDirectory() {
+    if (!isDirectory) return
+
+    listFiles()?.forEach {
+        it.delete()
+    }
 }
 
 internal fun Any.toJson(): String {

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/util/TurboFileProvider.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/util/TurboFileProvider.kt
@@ -1,0 +1,38 @@
+package dev.hotwire.turbo.util
+
+import android.content.Context
+import android.net.Uri
+import androidx.core.content.FileProvider
+import java.io.File
+import java.io.IOException
+
+@Suppress("MemberVisibilityCanBePrivate")
+class TurboFileProvider : FileProvider() {
+    companion object {
+        fun authority(context: Context): String {
+            return "${context.packageName}.turbo.fileprovider"
+        }
+
+        fun directory(context: Context): File {
+            val directory = File(context.filesDir, "shared")
+
+            if (!directory.mkdirs() && !directory.isDirectory) {
+                throw IOException("Could not create file provider directory")
+            }
+
+            return directory
+        }
+
+        fun contentUriForFile(context: Context, file: File): Uri {
+            return getUriForFile(context, authority(context), file)
+        }
+
+        suspend fun writeUriToFile(context: Context, uri: Uri): Uri? {
+            val uriHelper = TurboUriHelper(context)
+
+            return uriHelper.writeFileTo(uri, directory(context))?.let {
+                contentUriForFile(context, it)
+            }
+        }
+    }
+}

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/util/TurboFileProvider.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/util/TurboFileProvider.kt
@@ -3,6 +3,8 @@ package dev.hotwire.turbo.util
 import android.content.Context
 import android.net.Uri
 import androidx.core.content.FileProvider
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import java.io.File
 import java.io.IOException
 
@@ -32,6 +34,12 @@ class TurboFileProvider : FileProvider() {
 
             return uriHelper.writeFileTo(uri, directory(context))?.let {
                 contentUriForFile(context, it)
+            }
+        }
+
+        suspend fun deleteAllFiles(context: Context) {
+            withContext(Dispatchers.IO) {
+                directory(context).deleteAllFilesInDirectory()
             }
         }
     }

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/util/TurboFileProvider.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/util/TurboFileProvider.kt
@@ -3,7 +3,6 @@ package dev.hotwire.turbo.util
 import android.content.Context
 import android.net.Uri
 import androidx.core.content.FileProvider
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.io.File
 import java.io.IOException
@@ -38,7 +37,7 @@ class TurboFileProvider : FileProvider() {
         }
 
         suspend fun deleteAllFiles(context: Context) {
-            withContext(Dispatchers.IO) {
+            withContext(dispatcherProvider.io) {
                 directory(context).deleteAllFilesInDirectory()
             }
         }

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/util/TurboUriAttributes.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/util/TurboUriAttributes.kt
@@ -1,0 +1,7 @@
+package dev.hotwire.turbo.util
+
+data class TurboUriAttributes(
+    val fileName: String,
+    val mimeType: String,
+    val fileSize: Long
+)

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/util/TurboUriHelper.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/util/TurboUriHelper.kt
@@ -14,7 +14,7 @@ class TurboUriHelper(val context: Context) {
     suspend fun writeFileTo(uri: Uri, directory: File): File? {
         val uriAttributes = getAttributes(uri) ?: return null
 
-        return withContext(Dispatchers.IO) {
+        return withContext(dispatcherProvider.io) {
             val file = File(directory, uriAttributes.fileName).also {
                 if (it.exists()) it.delete()
             }

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/util/TurboUriHelper.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/util/TurboUriHelper.kt
@@ -1,0 +1,111 @@
+package dev.hotwire.turbo.util
+
+import android.content.Context
+import android.database.Cursor
+import android.net.Uri
+import android.provider.OpenableColumns
+import android.webkit.MimeTypeMap
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.File
+
+class TurboUriHelper(val context: Context) {
+    @Suppress("BlockingMethodInNonBlockingContext") // https://youtrack.jetbrains.com/issue/KT-39684
+    suspend fun writeFileTo(uri: Uri, directory: File): File? {
+        val uriAttributes = getAttributes(uri) ?: return null
+
+        return withContext(Dispatchers.IO) {
+            val file = File(directory, uriAttributes.fileName).also {
+                if (it.exists()) it.delete()
+            }
+
+            try {
+                context.contentResolver.openInputStream(uri).use {
+                    val outputStream = file.outputStream()
+                    it?.copyTo(outputStream)
+                    outputStream.close()
+                }
+                file
+            } catch (e: Exception) {
+                TurboLog.e("${e.message}")
+                null
+            }
+        }
+    }
+
+    fun getAttributes(uri: Uri): TurboUriAttributes? {
+        return when (uri.scheme) {
+            "file" -> getFileUriAttributes(uri)
+            "content" -> getContentUriAttributes(context, uri)
+            else -> null
+        }
+    }
+
+    private fun getFileUriAttributes(uri: Uri): TurboUriAttributes? {
+        val file = uri.getFile() ?: return null
+
+        return TurboUriAttributes(
+            fileName = file.name,
+            mimeType = uri.mimeType(),
+            fileSize = file.length()
+        )
+    }
+
+    private fun getContentUriAttributes(context: Context, uri: Uri): TurboUriAttributes? {
+        val projection = arrayOf(OpenableColumns.DISPLAY_NAME, OpenableColumns.SIZE)
+        val mimeType: String? = context.contentResolver.getType(uri)
+        val cursor = context.contentResolver.query(uri, projection, null, null, null)
+
+        val cursorAttributes = cursor?.use {
+            when (it.moveToFirst()) {
+                true -> uriAttributesFromContentQuery(uri, mimeType, it)
+                else -> null
+            }
+        }
+
+        return cursorAttributes ?: uriAttributesDerivedFromUri(uri, mimeType)
+    }
+
+    private fun uriAttributesFromContentQuery(uri: Uri, mimeType: String?, cursor: Cursor): TurboUriAttributes? {
+        val fileName: String? = cursor.getString(cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME))
+        val fileSize: Long = cursor.getLong(cursor.getColumnIndex(OpenableColumns.SIZE))
+
+        if (fileName == null && mimeType == null) {
+            return null
+        }
+
+        return TurboUriAttributes(
+            fileName = fileName ?: "attachment",
+            mimeType = mimeType ?: uri.mimeType(),
+            fileSize = fileSize
+        )
+    }
+
+    private fun uriAttributesDerivedFromUri(uri: Uri, mimeType: String?): TurboUriAttributes? {
+        val fileName: String? = uri.lastPathSegment
+
+        if (fileName == null && mimeType == null) {
+            return null
+        }
+
+        return TurboUriAttributes(
+            fileName = fileName ?: "attachment",
+            mimeType = mimeType ?: uri.mimeType(),
+            fileSize = 0
+        )
+    }
+
+    private fun Uri.fileExtension(): String? {
+        return lastPathSegment?.extract("\\.([0-9a-z]+)$")
+    }
+
+    private fun Uri?.mimeType(): String {
+        return this?.fileExtension()?.let {
+            MimeTypeMap.getSingleton().getMimeTypeFromExtension(it)
+        } ?: "application/octet-stream"
+    }
+
+    private fun Uri.getFile(): File? {
+        return path?.let { File(it) }
+    }
+}

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/views/TurboWebChromeClient.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/views/TurboWebChromeClient.kt
@@ -4,18 +4,17 @@ import android.net.Uri
 import android.webkit.ValueCallback
 import android.webkit.WebChromeClient
 import android.webkit.WebView
-import dev.hotwire.turbo.nav.TurboNavDestination
+import dev.hotwire.turbo.session.TurboSession
 
-open class TurboWebChromeClient(val destination: TurboNavDestination) : WebChromeClient() {
+open class TurboWebChromeClient(val session: TurboSession) : WebChromeClient() {
     override fun onShowFileChooser(
         webView: WebView,
         filePathCallback: ValueCallback<Array<Uri>>,
         fileChooserParams: FileChooserParams
     ): Boolean {
-        return destination.session.fileUploadDelegate.onShowFileChooser(
+        return session.fileUploadDelegate.onShowFileChooser(
             filePathCallback = filePathCallback,
             params = fileChooserParams,
-            destination = destination
         )
     }
 }

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/views/TurboWebChromeClient.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/views/TurboWebChromeClient.kt
@@ -1,0 +1,21 @@
+package dev.hotwire.turbo.views
+
+import android.net.Uri
+import android.webkit.ValueCallback
+import android.webkit.WebChromeClient
+import android.webkit.WebView
+import dev.hotwire.turbo.nav.TurboNavDestination
+
+open class TurboWebChromeClient(val destination: TurboNavDestination) : WebChromeClient() {
+    override fun onShowFileChooser(
+        webView: WebView,
+        filePathCallback: ValueCallback<Array<Uri>>,
+        fileChooserParams: FileChooserParams
+    ): Boolean {
+        return destination.session.fileUploadDelegate.onShowFileChooser(
+            filePathCallback = filePathCallback,
+            params = fileChooserParams,
+            destination = destination
+        )
+    }
+}

--- a/turbo/src/main/res/xml/file_provider_paths.xml
+++ b/turbo/src/main/res/xml/file_provider_paths.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+    <files-path
+        name="shared"
+        path="." />
+</paths>

--- a/turbo/src/test/kotlin/dev/hotwire/turbo/BaseRepositoryTest.kt
+++ b/turbo/src/test/kotlin/dev/hotwire/turbo/BaseRepositoryTest.kt
@@ -1,5 +1,6 @@
 package dev.hotwire.turbo
 
+import dev.hotwire.turbo.util.dispatcherProvider
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestCoroutineDispatcher
@@ -26,6 +27,7 @@ open class BaseRepositoryTest : BaseUnitTest() {
     override fun setup() {
         super.setup()
         Dispatchers.setMain(testDispatcher)
+        dispatcherProvider.io = Dispatchers.Main
         server.start()
     }
 

--- a/turbo/src/test/kotlin/dev/hotwire/turbo/delegates/TurboFileUploadDelegateTest.kt
+++ b/turbo/src/test/kotlin/dev/hotwire/turbo/delegates/TurboFileUploadDelegateTest.kt
@@ -34,12 +34,12 @@ class TurboFileUploadDelegateTest : BaseRepositoryTest() {
 
     @Before
     override fun setup() {
+        super.setup()
         MockitoAnnotations.openMocks(this)
 
         activity = buildActivity(TurboTestActivity::class.java).get()
         context = ApplicationProvider.getApplicationContext()
         session = TurboSession("test", activity, webView)
-        session.fileUploadDelegate.coroutineDispatcher = Dispatchers.Main
     }
 
     @Test

--- a/turbo/src/test/kotlin/dev/hotwire/turbo/delegates/TurboFileUploadDelegateTest.kt
+++ b/turbo/src/test/kotlin/dev/hotwire/turbo/delegates/TurboFileUploadDelegateTest.kt
@@ -1,0 +1,62 @@
+package dev.hotwire.turbo.delegates
+
+import android.app.Activity
+import android.os.Build
+import com.nhaarman.mockito_kotlin.whenever
+import dev.hotwire.turbo.nav.TurboNavDestination
+import dev.hotwire.turbo.session.TurboSession
+import dev.hotwire.turbo.util.TurboFileProvider
+import dev.hotwire.turbo.util.toJson
+import dev.hotwire.turbo.views.TurboWebView
+import dev.hotwire.turbo.visit.TurboVisit
+import dev.hotwire.turbo.visit.TurboVisitOptions
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.Mockito.verify
+import org.mockito.MockitoAnnotations
+import org.robolectric.Robolectric.buildActivity
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.io.File
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Build.VERSION_CODES.O])
+class TurboFileUploadDelegateTest {
+    @Mock
+    private lateinit var webView: TurboWebView
+    private lateinit var activity: Activity
+    private lateinit var session: TurboSession
+
+    @Before
+    fun setup() {
+        MockitoAnnotations.openMocks(this)
+
+        activity = buildActivity(TurboTestActivity::class.java).get()
+        session = TurboSession("test", activity, webView)
+        session.fileUploadDelegate.coroutineDispatcher = Dispatchers.Main
+    }
+
+    @Test
+    fun fileProviderDirectoryIsCleared() {
+        val dir = TurboFileProvider.directory(activity)
+
+        File(dir, "testFile.txt").apply {
+            writeText("text")
+        }
+
+        assertThat(dir.listFiles()?.size).isEqualTo(1)
+        assertThat(dir.listFiles()?.get(0)?.name).isEqualTo("testFile.txt")
+
+        runBlocking {
+            session.fileUploadDelegate.deleteCachedFiles()
+            assertThat(dir.listFiles()?.size).isEqualTo(0)
+        }
+    }
+}
+
+internal class TurboTestActivity : Activity()

--- a/turbo/src/test/kotlin/dev/hotwire/turbo/delegates/TurboFileUploadDelegateTest.kt
+++ b/turbo/src/test/kotlin/dev/hotwire/turbo/delegates/TurboFileUploadDelegateTest.kt
@@ -1,49 +1,50 @@
 package dev.hotwire.turbo.delegates
 
 import android.app.Activity
+import android.content.Context
 import android.os.Build
-import com.nhaarman.mockito_kotlin.whenever
-import dev.hotwire.turbo.nav.TurboNavDestination
+import androidx.test.core.app.ApplicationProvider
+import dev.hotwire.turbo.BaseRepositoryTest
 import dev.hotwire.turbo.session.TurboSession
 import dev.hotwire.turbo.util.TurboFileProvider
-import dev.hotwire.turbo.util.toJson
 import dev.hotwire.turbo.views.TurboWebView
-import dev.hotwire.turbo.visit.TurboVisit
-import dev.hotwire.turbo.visit.TurboVisitOptions
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
-import org.mockito.Mockito.verify
 import org.mockito.MockitoAnnotations
 import org.robolectric.Robolectric.buildActivity
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 import java.io.File
 
+@ExperimentalCoroutinesApi
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [Build.VERSION_CODES.O])
-class TurboFileUploadDelegateTest {
+class TurboFileUploadDelegateTest : BaseRepositoryTest() {
     @Mock
     private lateinit var webView: TurboWebView
     private lateinit var activity: Activity
+    private lateinit var context: Context
     private lateinit var session: TurboSession
 
     @Before
-    fun setup() {
+    override fun setup() {
         MockitoAnnotations.openMocks(this)
 
         activity = buildActivity(TurboTestActivity::class.java).get()
+        context = ApplicationProvider.getApplicationContext()
         session = TurboSession("test", activity, webView)
         session.fileUploadDelegate.coroutineDispatcher = Dispatchers.Main
     }
 
     @Test
     fun fileProviderDirectoryIsCleared() {
-        val dir = TurboFileProvider.directory(activity)
+        val dir = TurboFileProvider.directory(context)
 
         File(dir, "testFile.txt").apply {
             writeText("text")

--- a/turbo/src/test/kotlin/dev/hotwire/turbo/session/TurboSessionTest.kt
+++ b/turbo/src/test/kotlin/dev/hotwire/turbo/session/TurboSessionTest.kt
@@ -3,6 +3,7 @@ package dev.hotwire.turbo.session
 import android.app.Activity
 import android.os.Build
 import com.nhaarman.mockito_kotlin.whenever
+import dev.hotwire.turbo.nav.TurboNavDestination
 import dev.hotwire.turbo.util.toJson
 import dev.hotwire.turbo.views.TurboWebView
 import dev.hotwire.turbo.visit.TurboVisit
@@ -25,6 +26,8 @@ class TurboSessionTest {
     private lateinit var callback: TurboSessionCallback
     @Mock
     private lateinit var webView: TurboWebView
+    @Mock
+    private lateinit var navDestination: TurboNavDestination
     private lateinit var activity: Activity
     private lateinit var session: TurboSession
     private lateinit var visit: TurboVisit
@@ -45,7 +48,8 @@ class TurboSessionTest {
             options = TurboVisitOptions()
         )
 
-        whenever(callback.isActive()).thenReturn(true)
+        whenever(callback.visitNavDestination()).thenReturn(navDestination)
+        whenever(navDestination.isActive).thenReturn(true)
     }
 
     @Test


### PR DESCRIPTION
Allows file uploads from an `<input type=file>` element. The default `TurboWebChromeClient` behavior can be overridden by an app.