### PR TITLE
Add note about non-HTTPS sites

### DIFF
--- a/docs/QUICK-START.md
+++ b/docs/QUICK-START.md
@@ -13,7 +13,7 @@ A [`NavHostFragment`](https://developer.android.com/reference/androidx/navigatio
 The Turbo extension of this class, `TurboSessionNavHostFragment`, along with being responsible for self-contained `TurboFragment` navigation, also manages a `TurboSesssion` and a `TurboWebView` instance. You will need to implement a few things for this abstract class:
 
 * The name of the `TurboSession` (this is arbitrary, but must be unique in your app)
-* The url of a starting location when your app starts up
+* The url of a starting location when your app starts up. Note: if you're running your app locally without HTTPS, you'll need to adjust your `android:usesCleartextTraffic` settings in the AndroidManifest.xml to allow arbitrary loads.
 * A list of registered activities that Turbo will be able to navigate to (optional)
 * A list of registered fragments that Turbo will be able to navigate to
 * The location of your `TurboPathConfiguration` JSON file(s) to configure navigation rules

--- a/docs/QUICK-START.md
+++ b/docs/QUICK-START.md
@@ -13,7 +13,7 @@ A [`NavHostFragment`](https://developer.android.com/reference/androidx/navigatio
 The Turbo extension of this class, `TurboSessionNavHostFragment`, along with being responsible for self-contained `TurboFragment` navigation, also manages a `TurboSesssion` and a `TurboWebView` instance. You will need to implement a few things for this abstract class:
 
 * The name of the `TurboSession` (this is arbitrary, but must be unique in your app)
-* The url of a starting location when your app starts up. Note: if you're running your app locally without HTTPS, you'll need to adjust your `android:usesCleartextTraffic` settings in the AndroidManifest.xml to allow arbitrary loads.
+* The url of a starting location when your app starts up. Note: if you're running your app locally without HTTPS, you'll need to adjust your `android:usesCleartextTraffic` settings in the AndroidManifest.xml (or use an Android Network security configuration), and target [`10.0.2.2` instead of `localhost`](https://developer.android.com/studio/run/emulator-networking).
 * A list of registered activities that Turbo will be able to navigate to (optional)
 * A list of registered fragments that Turbo will be able to navigate to
 * The location of your `TurboPathConfiguration` JSON file(s) to configure navigation rules


### PR DESCRIPTION
I copied this from point 5 at https://github.com/hotwired/turbo-ios/blob/main/Docs/QuickStartGuide.md, then expanded a bit based on other Android gotchas I came across.