### PR TITLE
Fix crash while using a stylus to navigate within the WebView

### DIFF
--- a/turbo/src/main/kotlin/dev/hotwire/turbo/views/TurboSwipeRefreshLayout.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/views/TurboSwipeRefreshLayout.kt
@@ -2,15 +2,31 @@ package dev.hotwire.turbo.views
 
 import android.content.Context
 import android.util.AttributeSet
+import android.view.MotionEvent
 import android.webkit.WebView
 import androidx.core.view.children
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+import dev.hotwire.turbo.util.TurboLog
 
 internal class TurboSwipeRefreshLayout @JvmOverloads constructor(context: Context, attrs: AttributeSet? = null) :
         SwipeRefreshLayout(context, attrs) {
 
+    init {
+        disableCustomDrawingOrder()
+    }
+
     override fun canChildScrollUp(): Boolean {
         val webView = children.firstOrNull() as? WebView
         return webView?.scrollY ?: 0 > 0
+    }
+
+    /**
+     * Disable custom child drawing order. This fixes a crash while using a
+     * stylus that dispatches hover events when the WebView is being removed.
+     * This doesn't have any unintended consequences, since the WebView is the
+     * only possible child of this view.
+     */
+    private fun disableCustomDrawingOrder() {
+        isChildrenDrawingOrderEnabled = false
     }
 }

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/views/TurboSwipeRefreshLayout.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/views/TurboSwipeRefreshLayout.kt
@@ -2,11 +2,9 @@ package dev.hotwire.turbo.views
 
 import android.content.Context
 import android.util.AttributeSet
-import android.view.MotionEvent
 import android.webkit.WebView
 import androidx.core.view.children
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
-import dev.hotwire.turbo.util.TurboLog
 
 internal class TurboSwipeRefreshLayout @JvmOverloads constructor(context: Context, attrs: AttributeSet? = null) :
         SwipeRefreshLayout(context, attrs) {


### PR DESCRIPTION
This prevents the ViewGroup's dispatched hover events from trying to determine a custom order of its children when the WebView is being removed (there's no custom order anyway).