### PR TITLE
Prevent replacing the root destination with a modal destination

### DIFF
--- a/turbo/src/main/assets/json/test-configuration.json
+++ b/turbo/src/main/assets/json/test-configuration.json
@@ -58,6 +58,16 @@
       "properties": {
         "presentation": "none"
       }
+    },
+    {
+      "patterns": [
+        "/custom/modal"
+      ],
+      "properties": {
+        "context": "modal",
+        "uri": "turbo://fragment/web/modal",
+        "presentation": "replace_root"
+      }
     }
   ]
 }

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/nav/TurboNavException.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/nav/TurboNavException.kt
@@ -1,0 +1,3 @@
+package dev.hotwire.turbo.nav
+
+class TurboNavException(message: String) : Exception(message)

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/nav/TurboNavRule.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/nav/TurboNavRule.kt
@@ -45,6 +45,10 @@ internal class TurboNavRule(
     val newFallbackDestination = controller.destinationFor(newFallbackUri)
     val newNavOptions = newNavOptions(navOptions)
 
+    init {
+        verifyNavRules()
+    }
+
     private fun newPresentation(): TurboNavPresentation {
         // Use the custom presentation provided in the path configuration
         if (newProperties.presentation != TurboNavPresentation.DEFAULT) {
@@ -106,6 +110,13 @@ internal class TurboNavRule(
             bundle = newBundle,
             shouldNavigate = newProperties.presentation != TurboNavPresentation.NONE
         )
+    }
+
+    private fun verifyNavRules() {
+        if (newPresentationContext == TurboNavPresentationContext.MODAL &&
+            newPresentation == TurboNavPresentation.REPLACE_ROOT) {
+            throw TurboNavException("A `modal` destination cannot use presentation `REPLACE_ROOT`")
+        }
     }
 
     private fun NavController.destinationFor(uri: Uri?): NavDestination? {

--- a/turbo/src/test/kotlin/dev/hotwire/turbo/config/TurboPathConfigurationRepositoryTest.kt
+++ b/turbo/src/test/kotlin/dev/hotwire/turbo/config/TurboPathConfigurationRepositoryTest.kt
@@ -51,7 +51,7 @@ class TurboPathConfigurationRepositoryTest : BaseRepositoryTest() {
         assertThat(json).isNotNull()
 
         val config = load(json)
-        assertThat(config?.rules?.size).isEqualTo(6)
+        assertThat(config?.rules?.size).isEqualTo(7)
     }
 
     @Test

--- a/turbo/src/test/kotlin/dev/hotwire/turbo/config/TurboPathConfigurationTest.kt
+++ b/turbo/src/test/kotlin/dev/hotwire/turbo/config/TurboPathConfigurationTest.kt
@@ -33,7 +33,7 @@ class TurboPathConfigurationTest {
 
     @Test
     fun assetConfigurationIsLoaded() {
-        assertThat(pathConfiguration.rules.size).isEqualTo(6)
+        assertThat(pathConfiguration.rules.size).isEqualTo(7)
     }
 
     @Test

--- a/turbo/src/test/kotlin/dev/hotwire/turbo/nav/TurboNavRuleTest.kt
+++ b/turbo/src/test/kotlin/dev/hotwire/turbo/nav/TurboNavRuleTest.kt
@@ -15,6 +15,7 @@ import dev.hotwire.turbo.R
 import dev.hotwire.turbo.config.TurboPathConfiguration
 import dev.hotwire.turbo.visit.TurboVisitOptions
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -35,6 +36,7 @@ class TurboNavRuleTest {
     private val editUrl = "http://hotwire.dev/feature/edit"
     private val refreshUrl = "http://hotwire.dev/custom/refresh"
     private val resumeUrl = "http://hotwire.dev/custom/resume"
+    private val modalRootUrl = "http://hotwire.dev/custom/modal"
 
     private val webDestinationId = 1
     private val webModalDestinationId = 2
@@ -103,6 +105,13 @@ class TurboNavRuleTest {
         assertThat(rule.newDestinationUri).isEqualTo(webModalUri)
         assertThat(rule.newDestination).isNotNull()
         assertThat(rule.newNavOptions).isEqualTo(navOptions)
+    }
+
+    @Test
+    fun `navigate to modal context replacing root`() {
+        assertThatThrownBy { getNavigatorRule(modalRootUrl) }
+            .isInstanceOf(TurboNavException::class.java)
+            .hasMessage("A `modal` destination cannot use presentation `REPLACE_ROOT`")
     }
 
     @Test


### PR DESCRIPTION
This is not a supported situation. Modals should always have an underlying default context destination.

Addresses https://github.com/hotwired/turbo-android/issues/134