### PR TITLE
Allow a destination's contents to be refreshed

### DIFF
--- a/turbo/src/main/kotlin/dev/hotwire/turbo/delegates/TurboWebFragmentDelegate.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/delegates/TurboWebFragmentDelegate.kt
@@ -130,9 +130,9 @@ internal class TurboWebFragmentDelegate(
      * [dev.hotwire.turbo.nav.TurboNavDestination.refresh]
      */
     fun refresh(displayProgress: Boolean) {
-        turboView?.webViewRefresh?.let {
-            if (displayProgress && !it.isRefreshing) {
-                it.isRefreshing = true
+        turboView?.webViewRefresh?.apply {
+            if (displayProgress && !isRefreshing) {
+                isRefreshing = true
             }
         }
 
@@ -373,7 +373,7 @@ internal class TurboWebFragmentDelegate(
         turboView.webViewRefresh?.apply {
             isEnabled = navDestination.pathProperties.pullToRefreshEnabled
             setOnRefreshListener {
-                refresh(true)
+                refresh(displayProgress = true)
             }
         }
     }
@@ -381,7 +381,7 @@ internal class TurboWebFragmentDelegate(
     private fun initializeErrorPullToRefresh(turboView: TurboView) {
         turboView.errorRefresh?.apply {
             setOnRefreshListener {
-                refresh(true)
+                refresh(displayProgress = true)
             }
         }
     }

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/delegates/TurboWebFragmentDelegate.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/delegates/TurboWebFragmentDelegate.kt
@@ -126,6 +126,21 @@ internal class TurboWebFragmentDelegate(
     }
 
     /**
+     * Should be called by the implementing Fragment during
+     * [dev.hotwire.turbo.nav.TurboNavDestination.refresh]
+     */
+    fun refresh(displayProgress: Boolean) {
+        turboView?.webViewRefresh?.let {
+            if (displayProgress && !it.isRefreshing) {
+                it.isRefreshing = true
+            }
+        }
+
+        isWebViewAttachedToNewDestination = false
+        visit(location, restoreWithCachedSnapshot = false, reload = true)
+    }
+
+    /**
      * Retrieves the Turbo session from the destination.
      */
     fun session(): TurboSession {
@@ -358,8 +373,7 @@ internal class TurboWebFragmentDelegate(
         turboView.webViewRefresh?.apply {
             isEnabled = navDestination.pathProperties.pullToRefreshEnabled
             setOnRefreshListener {
-                isWebViewAttachedToNewDestination = false
-                visit(location, restoreWithCachedSnapshot = false, reload = true)
+                refresh(true)
             }
         }
     }
@@ -367,8 +381,7 @@ internal class TurboWebFragmentDelegate(
     private fun initializeErrorPullToRefresh(turboView: TurboView) {
         turboView.errorRefresh?.apply {
             setOnRefreshListener {
-                isWebViewAttachedToNewDestination = false
-                visit(location, restoreWithCachedSnapshot = false, reload = true)
+                refresh(true)
             }
         }
     }

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/fragments/TurboBottomSheetDialogFragment.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/fragments/TurboBottomSheetDialogFragment.kt
@@ -63,6 +63,8 @@ abstract class TurboBottomSheetDialogFragment : BottomSheetDialogFragment(),
 
     override fun onBeforeNavigation() {}
 
+    override fun refresh(displayProgress: Boolean) {}
+
     /**
      * Gets the Toolbar instance in your Fragment's view for use with
      * navigation. The title in the Toolbar will automatically be

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/fragments/TurboFragment.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/fragments/TurboFragment.kt
@@ -77,6 +77,8 @@ abstract class TurboFragment : Fragment(), TurboNavDestination {
 
     override fun onBeforeNavigation() {}
 
+    override fun refresh(displayProgress: Boolean) {}
+
     /**
      * Gets the Toolbar instance in your Fragment's view for use with
      * navigation. The title in the Toolbar will automatically be

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/fragments/TurboWebBottomSheetDialogFragment.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/fragments/TurboWebBottomSheetDialogFragment.kt
@@ -56,6 +56,10 @@ abstract class TurboWebBottomSheetDialogFragment : TurboBottomSheetDialogFragmen
         super.onDismiss(dialog)
     }
 
+    override fun refresh(displayProgress: Boolean) {
+        webDelegate.refresh(displayProgress)
+    }
+
     // ----------------------------------------------------------------------------
     // TurboWebFragmentCallback interface
     // ----------------------------------------------------------------------------

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/fragments/TurboWebFragment.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/fragments/TurboWebFragment.kt
@@ -68,6 +68,10 @@ abstract class TurboWebFragment : TurboFragment(), TurboWebFragmentCallback {
         }
     }
 
+    override fun refresh(displayProgress: Boolean) {
+        webDelegate.refresh(displayProgress)
+    }
+
     // ----------------------------------------------------------------------------
     // TurboWebFragmentCallback interface
     // ----------------------------------------------------------------------------

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/nav/TurboNavDestination.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/nav/TurboNavDestination.kt
@@ -15,7 +15,9 @@ import dev.hotwire.turbo.config.TurboPathConfiguration
 import dev.hotwire.turbo.config.TurboPathConfigurationProperties
 import dev.hotwire.turbo.delegates.TurboFragmentDelegate
 import dev.hotwire.turbo.delegates.TurboNestedFragmentDelegate
+import dev.hotwire.turbo.fragments.TurboFragment
 import dev.hotwire.turbo.fragments.TurboFragmentViewModel
+import dev.hotwire.turbo.fragments.TurboWebFragment
 import dev.hotwire.turbo.session.TurboSession
 import dev.hotwire.turbo.session.TurboSessionNavHostFragment
 import dev.hotwire.turbo.visit.TurboVisitOptions
@@ -99,6 +101,15 @@ interface TurboNavDestination {
      * for state cleanup in your Fragment if necessary.
      */
     fun onBeforeNavigation()
+
+    /**
+     * Refresh the destination's contents. In a [TurboWebFragment], this will perform
+     * a cold boot reload of the WebView location. In an all-native [TurboFragment]
+     * each subclass is responsible for implementing how to refresh its contents.
+     *
+     * @param displayProgress Whether progress should be displayed while refreshing.
+     */
+    fun refresh(displayProgress: Boolean = true)
 
     /**
      * Gets the nav host fragment that will be used for navigating to `newLocation`. You should


### PR DESCRIPTION
To refresh a destination's contents, simply call `refresh()`:
```kotlin
class WebFragment : TurboWebFragment() {

    // ...

    private fun respondToNativeFeature() {
        // Refresh the WebView contents
        refresh()

        // Or, refresh the contents without displaying progress
        refresh(displayProgress = false)
    }
}
```

To refresh the current destination from your Activity, use the `delegate`:
```kotlin
class MainActivity : AppCompatActivity(), TurboActivity {

    // ...

    private fun refreshAfterResumingApp() {
        delegate.currentNavDestination?.refresh()
    }
}
```

Addresses https://github.com/hotwired/turbo-android/issues/137