### PR TITLE
Allow all target="_blank" links to propose visits

### DIFF
--- a/turbo/src/main/kotlin/dev/hotwire/turbo/views/TurboWebChromeClient.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/views/TurboWebChromeClient.kt
@@ -1,10 +1,13 @@
 package dev.hotwire.turbo.views
 
 import android.net.Uri
+import android.os.Message
 import android.webkit.ValueCallback
 import android.webkit.WebChromeClient
 import android.webkit.WebView
 import dev.hotwire.turbo.session.TurboSession
+import dev.hotwire.turbo.util.toJson
+import dev.hotwire.turbo.visit.TurboVisitOptions
 
 open class TurboWebChromeClient(val session: TurboSession) : WebChromeClient() {
     override fun onShowFileChooser(
@@ -16,5 +19,19 @@ open class TurboWebChromeClient(val session: TurboSession) : WebChromeClient() {
             filePathCallback = filePathCallback,
             params = fileChooserParams
         )
+    }
+
+    override fun onCreateWindow(webView: WebView, isDialog: Boolean, isUserGesture: Boolean, resultMsg: Message?): Boolean {
+        val message = webView.handler.obtainMessage()
+        webView.requestFocusNodeHref(message)
+
+        message.data.getString("url")?.let {
+            session.visitProposedToLocation(
+                location = it,
+                optionsJson = TurboVisitOptions().toJson()
+            )
+        }
+
+        return false
     }
 }

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/views/TurboWebView.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/views/TurboWebView.kt
@@ -27,6 +27,7 @@ open class TurboWebView @JvmOverloads constructor(context: Context, attrs: Attri
     init {
         settings.javaScriptEnabled = true
         settings.domStorageEnabled = true
+        settings.setSupportMultipleWindows(true)
         layoutParams = FrameLayout.LayoutParams(MATCH_PARENT, MATCH_PARENT)
     }
 


### PR DESCRIPTION
Addresses https://github.com/hotwired/turbo-android/issues/144

Some `target="_blank"` links may not always propose visits (such as when embedded in `<iframe>` content), unless `webView.settings.setSupportMultipleWindows(true)` is enabled and `WebChromeClient.onCreateWindow()` is handled.