### PR TITLE
Ensure that WebView cookies are always persisted across app restarts

### DIFF
--- a/turbo/src/main/kotlin/dev/hotwire/turbo/activities/TurboActivityObserver.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/activities/TurboActivityObserver.kt
@@ -5,7 +5,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.OnLifecycleEvent
 
-class TurboActivityObserver : LifecycleObserver {
+internal class TurboActivityObserver : LifecycleObserver {
     /**
      * Cookies may not be persisted to storage yet, since WebView
      * maintains its own internal timing to flush in-memory cookies

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/activities/TurboActivityObserver.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/activities/TurboActivityObserver.kt
@@ -1,0 +1,19 @@
+package dev.hotwire.turbo.activities
+
+import android.webkit.CookieManager
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleObserver
+import androidx.lifecycle.OnLifecycleEvent
+
+class TurboActivityObserver : LifecycleObserver {
+    /**
+     * Cookies may not be persisted to storage yet, since WebView
+     * maintains its own internal timing to flush in-memory cookies
+     * to persistent storage. Ensure that cookies are maintained
+     * across app restarts.
+     */
+    @OnLifecycleEvent(Lifecycle.Event.ON_STOP)
+    fun persistWebViewCookies() {
+        CookieManager.getInstance().flush()
+    }
+}

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/delegates/TurboActivityDelegate.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/delegates/TurboActivityDelegate.kt
@@ -6,8 +6,8 @@ import androidx.annotation.IdRes
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
 import androidx.navigation.NavController
-import dev.hotwire.turbo.activities.TurboActivityObserver
 import dev.hotwire.turbo.nav.TurboNavDestination
+import dev.hotwire.turbo.observers.TurboActivityObserver
 import dev.hotwire.turbo.session.TurboSessionNavHostFragment
 import dev.hotwire.turbo.visit.TurboVisitOptions
 

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/delegates/TurboActivityDelegate.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/delegates/TurboActivityDelegate.kt
@@ -6,6 +6,7 @@ import androidx.annotation.IdRes
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
 import androidx.navigation.NavController
+import dev.hotwire.turbo.activities.TurboActivityObserver
 import dev.hotwire.turbo.nav.TurboNavDestination
 import dev.hotwire.turbo.session.TurboSessionNavHostFragment
 import dev.hotwire.turbo.visit.TurboVisitOptions
@@ -46,6 +47,7 @@ class TurboActivityDelegate(
      */
     init {
         registerNavHostFragment(currentNavHostFragmentId)
+        activity.lifecycle.addObserver(TurboActivityObserver())
         activity.onBackPressedDispatcher.addCallback(activity) {
             navigateBack()
         }

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/observers/TurboActivityObserver.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/observers/TurboActivityObserver.kt
@@ -1,4 +1,4 @@
-package dev.hotwire.turbo.activities
+package dev.hotwire.turbo.observers
 
 import android.webkit.CookieManager
 import androidx.lifecycle.Lifecycle


### PR DESCRIPTION
Addresses #148 

`WebView` maintains its own internal timing to flush in-memory cookies to persistent storage. This means cookies may not have been persisted before leaving the app. Ensure that cookies are always flushed when the `TurboActivity` stops.