### PR TITLE
Don't call `webView.reload()` if the webView has no current URL

### DIFF
--- a/demo/src/main/kotlin/dev/hotwire/turbo/demo/main/MainActivity.kt
+++ b/demo/src/main/kotlin/dev/hotwire/turbo/demo/main/MainActivity.kt
@@ -1,18 +1,42 @@
 package dev.hotwire.turbo.demo.main
 
+import android.content.Context
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import dev.hotwire.turbo.activities.TurboActivity
 import dev.hotwire.turbo.delegates.TurboActivityDelegate
 import dev.hotwire.turbo.demo.R
+import kotlin.math.abs
 
 class MainActivity : AppCompatActivity(), TurboActivity {
     override lateinit var delegate: TurboActivityDelegate
+
+    val ONE_HOUR = 60 * 60 * 1000 // in ms
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
 
         delegate = TurboActivityDelegate(this, R.id.main_nav_host)
+    }
+
+    override fun onPause() {
+        super.onPause()
+
+        getSharedPreferences("SHARED_PREFERENCES", Context.MODE_PRIVATE).edit()
+            .putLong("APP_LAST_ENTERED_BACKGROUND", System.currentTimeMillis()).apply()
+    }
+
+    override fun onResume() {
+        super.onResume()
+
+        val lastResume = getSharedPreferences("SHARED_PREFERENCES", Context.MODE_PRIVATE)
+            .getLong("APP_LAST_ENTERED_BACKGROUND", System.currentTimeMillis())
+        val diff = abs(System.currentTimeMillis() - lastResume)
+
+        // if app last opened more than an hour ago, reload the last page open to ensure fresh content
+        if (diff >= ONE_HOUR) {
+            delegate.refresh()
+        }
     }
 }

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/session/TurboSession.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/session/TurboSession.kt
@@ -418,7 +418,11 @@ class TurboSession internal constructor(
         // sees a WebView.loadUrl() request as a same-page visit instead of
         // requesting a full page reload. To work around this, we call
         // WebView.reload(), which fully reloads the page for all URLs.
-        when (visit.reload) {
+        //
+        // Note that webView.url is null if you call reload() before the webView
+        // has successfully loaded a URL, or if the URL webView is unloaded
+        // (eg by force closing the app). In this case we load the URL as normal.
+        when (visit.reload && webView.url != null) {
             true -> webView.reload()
             else -> webView.loadUrl(visit.location)
         }


### PR DESCRIPTION
The functionality added in https://github.com/hotwired/turbo-android/pull/138 (as well as my workaround in https://github.com/hotwired/turbo-android/issues/137) had a bug: if the webView has no URL loaded, calling `refresh` will result in a spinner appearing forever, and no requests being made to the server.

To replicate this:

- Add a call to `delegate.refresh()` in `onResume`
- Force close the app
- Open the app

Our real life example was that we had a call to `refresh()` in `onResume` that ran if the app had not been open for a while, to ensure fresh content. I have included an example of how to replicate this in the demo, but don't mind if it gets removed before merging. The fix is to not call `webView.reload()` if `webView.url` is null. Instead just load the URL as normal.

(Is there a better approach to this? How does Basecamp/Hey ensure fresh content on app load - either because the app was in memory in the background for a while or because Turbo/the Webview has cached the last screen?)