### PR TITLE
Don't attempt to navigate to invalid URLs

### DIFF
--- a/turbo/src/main/kotlin/dev/hotwire/turbo/nav/TurboNavDestination.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/nav/TurboNavDestination.kt
@@ -21,6 +21,7 @@ import dev.hotwire.turbo.fragments.TurboWebFragment
 import dev.hotwire.turbo.session.TurboSession
 import dev.hotwire.turbo.session.TurboSessionNavHostFragment
 import dev.hotwire.turbo.visit.TurboVisitOptions
+import java.net.URL
 
 /**
  * The primary interface that a navigable Fragment implements to provide the library with
@@ -127,7 +128,12 @@ interface TurboNavDestination {
      * Turbo navigation flow).
      */
     fun shouldNavigateTo(newLocation: String): Boolean {
-        return true
+        return try {
+            URL(newLocation)
+            true
+        } catch (e: java.net.MalformedURLException) {
+            false
+        }
     }
 
     /**


### PR DESCRIPTION
Currently Turbo Native will attempt to navigate to any link, even if it's not a valid URL. This can cause the app to crash ([here](https://github.com/hotwired/turbo-android/blob/main/turbo/src/main/kotlin/dev/hotwire/turbo/config/TurboPathConfiguration.kt#L93)) if you click on a link like `sms:+55555555?body=hi`, since `URL(location)` doesn't recognise `sms:` links as valid.

To properly handle this you should implement [this code](https://github.com/hotwired/turbo-android/blob/main/demo/src/main/kotlin/dev/hotwire/turbo/demo/base/NavDestination.kt#L18..L57). But if you forget to, or if someone working on the web app ships a new link without you knowing about it, you don't want this to cause a scenario where clicking a link can crash the native app.

This PR avoids that, by not navigating to a link that can't be parsed to a URL by default. Now, rather than crashing the app, the link does nothing. Still not great, but not as bad.

If you've overridden `shouldNavigateTo` this shouldn't change anything for you.