### PR TITLE
Remove onActivityCreated() use from all library fragments

### DIFF
--- a/demo/src/main/kotlin/dev/hotwire/turbo/demo/features/imageviewer/ImageViewerFragment.kt
+++ b/demo/src/main/kotlin/dev/hotwire/turbo/demo/features/imageviewer/ImageViewerFragment.kt
@@ -18,13 +18,9 @@ class ImageViewerFragment : TurboFragment(), NavDestination {
         return inflater.inflate(R.layout.fragment_image_viewer, container, false)
     }
 
-    override fun onActivityCreated(savedInstanceState: Bundle?) {
-        super.onActivityCreated(savedInstanceState)
-        initToolbar()
-    }
-
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        initToolbar()
         loadImage(view)
     }
 

--- a/demo/src/main/kotlin/dev/hotwire/turbo/demo/features/web/WebModalFragment.kt
+++ b/demo/src/main/kotlin/dev/hotwire/turbo/demo/features/web/WebModalFragment.kt
@@ -1,13 +1,14 @@
 package dev.hotwire.turbo.demo.features.web
 
 import android.os.Bundle
+import android.view.View
 import dev.hotwire.turbo.demo.util.displayBackButtonAsCloseIcon
 import dev.hotwire.turbo.nav.TurboNavGraphDestination
 
 @TurboNavGraphDestination(uri = "turbo://fragment/web/modal")
 class WebModalFragment : WebFragment() {
-    override fun onActivityCreated(savedInstanceState: Bundle?) {
-        super.onActivityCreated(savedInstanceState)
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
         initToolbar()
     }
 

--- a/turbo/build.gradle
+++ b/turbo/build.gradle
@@ -99,6 +99,7 @@ dependencies {
     api 'androidx.appcompat:appcompat:1.2.0'
     api 'androidx.core:core-ktx:1.3.2'
     api 'androidx.webkit:webkit:1.4.0'
+    api 'androidx.fragment:fragment-ktx:1.3.2'
     api 'androidx.navigation:navigation-fragment-ktx:2.3.5'
     api 'androidx.navigation:navigation-ui-ktx:2.3.5'
 

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/delegates/TurboFragmentDelegate.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/delegates/TurboFragmentDelegate.kt
@@ -33,7 +33,7 @@ class TurboFragmentDelegate(private val navDestination: TurboNavDestination) {
         navigator = TurboNavigator(navDestination)
 
         initToolbar()
-        logEvent("fragment.onActivityCreated", "location" to location)
+        logEvent("fragment.onViewCreated", "location" to location)
     }
 
     /**

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/delegates/TurboFragmentDelegate.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/delegates/TurboFragmentDelegate.kt
@@ -27,9 +27,9 @@ class TurboFragmentDelegate(private val navDestination: TurboNavDestination) {
 
     /**
      * Should be called by the implementing Fragment during
-     * [androidx.fragment.app.Fragment.onActivityCreated].
+     * [androidx.fragment.app.Fragment.onViewCreated].
      */
-    fun onActivityCreated() {
+    fun onViewCreated() {
         navigator = TurboNavigator(navDestination)
 
         initToolbar()

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/delegates/TurboWebFragmentDelegate.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/delegates/TurboWebFragmentDelegate.kt
@@ -54,9 +54,9 @@ internal class TurboWebFragmentDelegate(
 
     /**
      * Should be called by the implementing Fragment during
-     * [androidx.fragment.app.Fragment.onActivityCreated].
+     * [androidx.fragment.app.Fragment.onViewCreated].
      */
-    fun onActivityCreated() {
+    fun onViewCreated() {
         if (session().isRenderProcessGone) {
             navDestination.sessionNavHostFragment.createNewSession()
         }

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/fragments/TurboBottomSheetDialogFragment.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/fragments/TurboBottomSheetDialogFragment.kt
@@ -4,11 +4,11 @@ import android.content.DialogInterface
 import android.os.Bundle
 import android.view.View
 import androidx.appcompat.widget.Toolbar
-import dev.hotwire.turbo.delegates.TurboFragmentDelegate
-import dev.hotwire.turbo.nav.TurboNavDestination
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import dev.hotwire.turbo.R
 import dev.hotwire.turbo.config.title
+import dev.hotwire.turbo.delegates.TurboFragmentDelegate
+import dev.hotwire.turbo.nav.TurboNavDestination
 
 /**
  * The base class from which all bottom sheet native fragments in a
@@ -27,6 +27,7 @@ abstract class TurboBottomSheetDialogFragment : BottomSheetDialogFragment(),
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        delegate.onViewCreated()
 
         if (shouldObserveTitleChanges()) {
             observeTitleChanges()
@@ -36,9 +37,16 @@ abstract class TurboBottomSheetDialogFragment : BottomSheetDialogFragment(),
         }
     }
 
-    override fun onActivityCreated(savedInstanceState: Bundle?) {
+    /**
+     * @deprecated use {@link #onViewCreated(View, Bundle)} for code touching
+     * the Fragment's view and {@link #onCreate(Bundle)} for other initialization.
+     *
+     * This is marked `final` to prevent further use, as it's now deprecated in
+     * AndroidX's Fragment implementation.
+     */
+    @Suppress("DEPRECATION")
+    final override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
-        delegate.onActivityCreated()
     }
 
     override fun onStart() {

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/fragments/TurboBottomSheetDialogFragment.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/fragments/TurboBottomSheetDialogFragment.kt
@@ -38,11 +38,11 @@ abstract class TurboBottomSheetDialogFragment : BottomSheetDialogFragment(),
     }
 
     /**
-     * @deprecated use {@link #onViewCreated(View, Bundle)} for code touching
-     * the Fragment's view and {@link #onCreate(Bundle)} for other initialization.
-     *
      * This is marked `final` to prevent further use, as it's now deprecated in
      * AndroidX's Fragment implementation.
+     *
+     * Use [onViewCreated] for code touching
+     * the Fragment's view and [onCreate] for other initialization.
      */
     @Suppress("DEPRECATION")
     final override fun onActivityCreated(savedInstanceState: Bundle?) {

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/fragments/TurboFragment.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/fragments/TurboFragment.kt
@@ -29,6 +29,8 @@ abstract class TurboFragment : Fragment(), TurboNavDestination {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        delegate.onViewCreated()
+
         observeModalResult()
         observeDialogResult()
         observeTheme()
@@ -41,9 +43,16 @@ abstract class TurboFragment : Fragment(), TurboNavDestination {
         }
     }
 
-    override fun onActivityCreated(savedInstanceState: Bundle?) {
+    /**
+     * @deprecated use {@link #onViewCreated(View, Bundle)} for code touching
+     * the Fragment's view and {@link #onCreate(Bundle)} for other initialization.
+     *
+     * This is marked `final` to prevent further use, as it's now deprecated in
+     * AndroidX's Fragment implementation.
+     */
+    @Suppress("DEPRECATION")
+    final override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
-        delegate.onActivityCreated()
     }
 
     override fun onStart() {

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/fragments/TurboFragment.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/fragments/TurboFragment.kt
@@ -44,11 +44,11 @@ abstract class TurboFragment : Fragment(), TurboNavDestination {
     }
 
     /**
-     * @deprecated use {@link #onViewCreated(View, Bundle)} for code touching
-     * the Fragment's view and {@link #onCreate(Bundle)} for other initialization.
-     *
      * This is marked `final` to prevent further use, as it's now deprecated in
      * AndroidX's Fragment implementation.
+     *
+     * Use [onViewCreated] for code touching
+     * the Fragment's view and [onCreate] for other initialization.
      */
     @Suppress("DEPRECATION")
     final override fun onActivityCreated(savedInstanceState: Bundle?) {

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/fragments/TurboWebBottomSheetDialogFragment.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/fragments/TurboWebBottomSheetDialogFragment.kt
@@ -32,9 +32,9 @@ abstract class TurboWebBottomSheetDialogFragment : TurboBottomSheetDialogFragmen
         return inflater.inflate(R.layout.turbo_fragment_web_bottom_sheet, container, false)
     }
 
-    override fun onActivityCreated(savedInstanceState: Bundle?) {
-        super.onActivityCreated(savedInstanceState)
-        webDelegate.onActivityCreated()
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        webDelegate.onViewCreated()
     }
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, intent: Intent?) {

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/fragments/TurboWebFragment.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/fragments/TurboWebFragment.kt
@@ -30,9 +30,9 @@ abstract class TurboWebFragment : TurboFragment(), TurboWebFragmentCallback {
         return inflater.inflate(R.layout.turbo_fragment_web, container, false)
     }
 
-    override fun onActivityCreated(savedInstanceState: Bundle?) {
-        super.onActivityCreated(savedInstanceState)
-        webDelegate.onActivityCreated()
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        webDelegate.onViewCreated()
     }
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, intent: Intent?) {


### PR DESCRIPTION
AndroidX has deprecated `Fragment.onActivityCreated()`, so prevent its further use in the library and consuming apps.