### PR TITLE
Remove onActivityResult() use from all library Fragments

### DIFF
--- a/turbo/src/main/kotlin/dev/hotwire/turbo/delegates/TurboFileChooserDelegate.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/delegates/TurboFileChooserDelegate.kt
@@ -6,6 +6,7 @@ import android.content.Intent
 import android.net.Uri
 import android.webkit.ValueCallback
 import android.webkit.WebChromeClient.FileChooserParams
+import androidx.activity.result.ActivityResult
 import dev.hotwire.turbo.R
 import dev.hotwire.turbo.session.TurboSession
 import dev.hotwire.turbo.util.TURBO_REQUEST_CODE_FILES
@@ -37,11 +38,9 @@ internal class TurboFileChooserDelegate(val session: TurboSession) : CoroutineSc
         }
     }
 
-    fun onActivityResult(requestCode: Int, resultCode: Int, intent: Intent?) {
-        if (requestCode != TURBO_REQUEST_CODE_FILES) return
-
-        when (resultCode) {
-            Activity.RESULT_OK -> handleResult(intent)
+    fun onActivityResult(result: ActivityResult) {
+        when (result.resultCode) {
+            Activity.RESULT_OK -> handleResult(result.data)
             Activity.RESULT_CANCELED -> handleCancellation()
         }
     }
@@ -70,7 +69,7 @@ internal class TurboFileChooserDelegate(val session: TurboSession) : CoroutineSc
         val destination = session.currentVisitNavDestination ?: return false
 
         return try {
-            destination.fragment.startActivityForResult(intent, TURBO_REQUEST_CODE_FILES)
+            destination.activityResultLauncher(TURBO_REQUEST_CODE_FILES)?.launch(intent)
             true
         } catch (e: Exception) {
             TurboLog.e("${e.message}")

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/delegates/TurboWebFragmentDelegate.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/delegates/TurboWebFragmentDelegate.kt
@@ -3,6 +3,8 @@ package dev.hotwire.turbo.delegates
 import android.content.Intent
 import android.graphics.Bitmap
 import android.webkit.HttpAuthHandler
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.contract.ActivityResultContracts.StartActivityForResult
 import androidx.lifecycle.lifecycleScope
 import dev.hotwire.turbo.config.pullToRefreshEnabled
 import dev.hotwire.turbo.fragments.TurboWebFragmentCallback
@@ -17,7 +19,6 @@ import dev.hotwire.turbo.views.TurboWebView
 import dev.hotwire.turbo.visit.TurboVisit
 import dev.hotwire.turbo.visit.TurboVisitAction
 import dev.hotwire.turbo.visit.TurboVisitOptions
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlin.random.Random
@@ -53,6 +54,11 @@ internal class TurboWebFragmentDelegate(
         get() = session().webView
 
     /**
+     * The activity result launcher that handles file chooser results.
+     */
+    val fileChooserResultLauncher = registerFileChooserLauncher()
+
+    /**
      * Should be called by the implementing Fragment during
      * [androidx.fragment.app.Fragment.onViewCreated].
      */
@@ -66,14 +72,6 @@ internal class TurboWebFragmentDelegate(
             session().removeCallback(this)
             detachWebView(onReady)
         }
-    }
-
-    /**
-     * Should be called by the implementing Fragment during
-     * [androidx.fragment.app.Fragment.onActivityResult].
-     */
-    fun onActivityResult(requestCode: Int, resultCode: Int, intent: Intent?) {
-        session().fileChooserDelegate.onActivityResult(requestCode, resultCode, intent)
     }
 
     /**
@@ -312,6 +310,12 @@ internal class TurboWebFragmentDelegate(
 
     private fun title(): String {
         return webView.title ?: ""
+    }
+
+    private fun registerFileChooserLauncher(): ActivityResultLauncher<Intent> {
+        return navDestination.fragment.registerForActivityResult(StartActivityForResult()) { result ->
+            session().fileChooserDelegate.onActivityResult(result)
+        }
     }
 
     private fun visit(location: String, restoreWithCachedSnapshot: Boolean, reload: Boolean) {

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/fragments/TurboBottomSheetDialogFragment.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/fragments/TurboBottomSheetDialogFragment.kt
@@ -1,6 +1,7 @@
 package dev.hotwire.turbo.fragments
 
 import android.content.DialogInterface
+import android.content.Intent
 import android.os.Bundle
 import android.view.View
 import androidx.appcompat.widget.Toolbar
@@ -47,6 +48,21 @@ abstract class TurboBottomSheetDialogFragment : BottomSheetDialogFragment(),
     @Suppress("DEPRECATION")
     final override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
+    }
+
+    /**
+     * This is marked `final` to prevent further use, as it's now deprecated in
+     * AndroidX's Fragment implementation.
+     *
+     * Use [registerForActivityResult] with the appropriate
+     * [androidx.activity.result.contract.ActivityResultContract] and its callback.
+     *
+     * Turbo provides the [TurboNavDestination.activityResultLauncher] interface
+     * to obtain registered result launchers from any destination.
+     */
+    @Suppress("DEPRECATION")
+    final override fun onActivityResult(requestCode: Int, resultCode: Int, intent: Intent?) {
+        super.onActivityResult(requestCode, resultCode, intent)
     }
 
     override fun onStart() {

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/fragments/TurboFragment.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/fragments/TurboFragment.kt
@@ -1,5 +1,6 @@
 package dev.hotwire.turbo.fragments
 
+import android.content.Intent
 import android.os.Bundle
 import android.view.View
 import androidx.appcompat.widget.Toolbar
@@ -53,6 +54,21 @@ abstract class TurboFragment : Fragment(), TurboNavDestination {
     @Suppress("DEPRECATION")
     final override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
+    }
+
+    /**
+     * This is marked `final` to prevent further use, as it's now deprecated in
+     * AndroidX's Fragment implementation.
+     *
+     * Use [registerForActivityResult] with the appropriate
+     * [androidx.activity.result.contract.ActivityResultContract] and its callback.
+     *
+     * Turbo provides the [TurboNavDestination.activityResultLauncher] interface
+     * to obtain registered result launchers from any destination.
+     */
+    @Suppress("DEPRECATION")
+    final override fun onActivityResult(requestCode: Int, resultCode: Int, intent: Intent?) {
+        super.onActivityResult(requestCode, resultCode, intent)
     }
 
     override fun onStart() {

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/fragments/TurboWebBottomSheetDialogFragment.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/fragments/TurboWebBottomSheetDialogFragment.kt
@@ -7,8 +7,10 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.activity.result.ActivityResultLauncher
 import dev.hotwire.turbo.R
 import dev.hotwire.turbo.delegates.TurboWebFragmentDelegate
+import dev.hotwire.turbo.util.TURBO_REQUEST_CODE_FILES
 import dev.hotwire.turbo.views.TurboView
 import dev.hotwire.turbo.views.TurboWebChromeClient
 
@@ -37,8 +39,11 @@ abstract class TurboWebBottomSheetDialogFragment : TurboBottomSheetDialogFragmen
         webDelegate.onViewCreated()
     }
 
-    override fun onActivityResult(requestCode: Int, resultCode: Int, intent: Intent?) {
-        webDelegate.onActivityResult(requestCode, resultCode, intent)
+    override fun activityResultLauncher(requestCode: Int): ActivityResultLauncher<Intent>? {
+        return when (requestCode) {
+            TURBO_REQUEST_CODE_FILES -> webDelegate.fileChooserResultLauncher
+            else -> null
+        }
     }
 
     override fun onStart() {

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/fragments/TurboWebFragment.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/fragments/TurboWebFragment.kt
@@ -6,9 +6,11 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.activity.result.ActivityResultLauncher
 import dev.hotwire.turbo.R
 import dev.hotwire.turbo.delegates.TurboWebFragmentDelegate
 import dev.hotwire.turbo.session.TurboSessionModalResult
+import dev.hotwire.turbo.util.TURBO_REQUEST_CODE_FILES
 import dev.hotwire.turbo.views.TurboView
 import dev.hotwire.turbo.views.TurboWebChromeClient
 
@@ -33,10 +35,6 @@ abstract class TurboWebFragment : TurboFragment(), TurboWebFragmentCallback {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         webDelegate.onViewCreated()
-    }
-
-    override fun onActivityResult(requestCode: Int, resultCode: Int, intent: Intent?) {
-        webDelegate.onActivityResult(requestCode, resultCode, intent)
     }
 
     override fun onStart() {
@@ -70,6 +68,13 @@ abstract class TurboWebFragment : TurboFragment(), TurboWebFragmentCallback {
 
     override fun refresh(displayProgress: Boolean) {
         webDelegate.refresh(displayProgress)
+    }
+
+    override fun activityResultLauncher(requestCode: Int): ActivityResultLauncher<Intent>? {
+        return when (requestCode) {
+            TURBO_REQUEST_CODE_FILES -> webDelegate.fileChooserResultLauncher
+            else -> null
+        }
     }
 
     // ----------------------------------------------------------------------------

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/nav/TurboNavDestination.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/nav/TurboNavDestination.kt
@@ -1,6 +1,8 @@
 package dev.hotwire.turbo.nav
 
+import android.content.Intent
 import android.os.Bundle
+import androidx.activity.result.ActivityResultLauncher
 import androidx.annotation.IdRes
 import androidx.appcompat.widget.Toolbar
 import androidx.fragment.app.Fragment
@@ -188,6 +190,20 @@ interface TurboNavDestination {
      */
     fun clearBackStack(onCleared: () -> Unit = {}) {
         navigator.clearBackStack(onCleared)
+    }
+
+    /**
+     * Gets a registered activity result launcher instance for the given `requestCode`.
+     *
+     * Override to provide your own [androidx.activity.result.ActivityResultLauncher]
+     * instances. If your app doesn't have a matching `requestCode`, you must call
+     * `super.activityResultLauncher(requestCode)` to give the Turbo library an
+     * opportunity to provide a matching result launcher.
+     *
+     * @param requestCode The request code for the corresponding result launcher.
+     */
+    fun activityResultLauncher(requestCode: Int): ActivityResultLauncher<Intent>? {
+        return null
     }
 
     /**


### PR DESCRIPTION
AndroidX has deprecated `Fragment.onActivityResult()`, so prevent its further use in the library and consuming apps.