### PR TITLE
Fix QUICK-START.md for 7.0.0-beta11

### DIFF
--- a/docs/QUICK-START.md
+++ b/docs/QUICK-START.md
@@ -27,7 +27,7 @@ class MainSessionNavHostFragment : TurboSessionNavHostFragment() {
 
     override val startLocation = "https://turbo-native-demo.glitch.me/"
 
-    override val registeredActivities: List<KClass<out Activity>>
+    override val registeredActivities: List<KClass<out AppCompatActivity>>
         get() = listOf(
             // Leave empty unless you have more 
             // than one TurboActivity in your app


### PR DESCRIPTION
Fix the type of `TurboSessionNavHostFragment#registeredActivities`