### PR TITLE
Ignore the web fragment `refresh()` if the WebView doesn't have a url loaded yet

### DIFF
--- a/turbo/src/main/kotlin/dev/hotwire/turbo/delegates/TurboWebFragmentDelegate.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/delegates/TurboWebFragmentDelegate.kt
@@ -128,6 +128,8 @@ internal class TurboWebFragmentDelegate(
      * [dev.hotwire.turbo.nav.TurboNavDestination.refresh]
      */
     fun refresh(displayProgress: Boolean) {
+        if (webView.url == null) return
+
         turboView?.webViewRefresh?.apply {
             if (displayProgress && !isRefreshing) {
                 isRefreshing = true


### PR DESCRIPTION
Addresses the issue outlined in #161.