### PR TITLE
Synthetically restore the session's current visit if the WebView's visit hasn't changed

### DIFF
--- a/turbo/src/main/kotlin/dev/hotwire/turbo/delegates/TurboWebFragmentDelegate.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/delegates/TurboWebFragmentDelegate.kt
@@ -90,6 +90,7 @@ internal class TurboWebFragmentDelegate(
     fun onStartAfterModalResult(result: TurboSessionModalResult) {
         if (!result.shouldNavigate) {
             initNavigationVisit()
+            initWebChromeClient()
         }
     }
 
@@ -300,9 +301,15 @@ internal class TurboWebFragmentDelegate(
 
             // Visit every time the WebView is reattached to the current Fragment.
             if (isWebViewAttachedToNewDestination) {
-                showProgressView(location)
-                visit(location, restoreWithCachedSnapshot = !isInitialVisit, reload = false)
-                isInitialVisit = false
+                val currentSessionVisitRestored = !isInitialVisit &&
+                    session().currentVisit?.destinationIdentifier == identifier &&
+                    session().restoreCurrentVisit(this)
+
+                if (!currentSessionVisitRestored) {
+                    showProgressView(location)
+                    visit(location, restoreWithCachedSnapshot = !isInitialVisit, reload = false)
+                    isInitialVisit = false
+                }
             }
         }
     }

--- a/turbo/src/test/kotlin/dev/hotwire/turbo/session/TurboSessionTest.kt
+++ b/turbo/src/test/kotlin/dev/hotwire/turbo/session/TurboSessionTest.kt
@@ -2,6 +2,8 @@ package dev.hotwire.turbo.session
 
 import android.os.Build
 import androidx.appcompat.app.AppCompatActivity
+import com.nhaarman.mockito_kotlin.never
+import com.nhaarman.mockito_kotlin.times
 import com.nhaarman.mockito_kotlin.whenever
 import dev.hotwire.turbo.nav.TurboNavDestination
 import dev.hotwire.turbo.util.toJson
@@ -153,6 +155,43 @@ class TurboSessionTest {
 
         assertThat(session.coldBootVisitIdentifier).isEmpty()
         assertThat(session.currentVisit?.identifier).isEmpty()
+    }
+
+    @Test
+    fun restoreCurrentVisit() {
+        val visitIdentifier = "12345"
+        val restorationIdentifier = "67890"
+
+        session.currentVisit = visit.copy(identifier = visitIdentifier)
+        session.turboIsReady(true)
+        session.pageLoaded(restorationIdentifier)
+
+        assertThat(session.restoreCurrentVisit(callback)).isTrue()
+        verify(callback, times(2)).visitCompleted(false)
+    }
+
+    @Test
+    fun restoreCurrentVisitFailsWithNoRestorationIdentifier() {
+        val visitIdentifier = "12345"
+
+        session.currentVisit = visit.copy(identifier = visitIdentifier)
+        session.turboIsReady(true)
+
+        assertThat(session.restoreCurrentVisit(callback)).isFalse()
+        verify(callback, times(1)).visitCompleted(false)
+    }
+
+    @Test
+    fun restoreCurrentVisitFailsWithSessionNotReady() {
+        val visitIdentifier = "12345"
+        val restorationIdentifier = "67890"
+
+        session.currentVisit = visit.copy(identifier = visitIdentifier)
+        session.pageLoaded(restorationIdentifier)
+        session.turboIsReady(false)
+
+        assertThat(session.restoreCurrentVisit(callback)).isFalse()
+        verify(callback, never()).visitCompleted(false)
     }
 
     @Test


### PR DESCRIPTION
The WebView is always detached from the current Fragment destination before visiting a new Fragment destination. 

Consider the following flow:
1. Destination `A` is the current web destination
2. Start visit to destination `B` (WebView is detached from `A`)
3. Destination `B` is current destination and is all native (no WebView)
4. Go back to destination `A` in the backstack
5. WebView is reattached to destination `A`. The WebView visit is still displaying `A`'s visit location. We no longer perform a Turbo `restore` visit to `A`'s location, since this would be considered a same-page visit. Instead, synthetically call `visitRendered()` and `visitCompleted()`, since the WebView is already displaying the correct location contents.