### PR TITLE
Implement the form submission adapter APIs 

### DIFF
--- a/demo/src/main/kotlin/dev/hotwire/turbo/demo/base/NavDestination.kt
+++ b/demo/src/main/kotlin/dev/hotwire/turbo/demo/base/NavDestination.kt
@@ -1,7 +1,6 @@
 package dev.hotwire.turbo.demo.base
 
 import android.net.Uri
-import android.view.Menu
 import android.view.MenuItem
 import androidx.browser.customtabs.CustomTabColorSchemeParams
 import androidx.browser.customtabs.CustomTabsIntent
@@ -13,8 +12,7 @@ import dev.hotwire.turbo.config.context
 import dev.hotwire.turbo.demo.R
 import dev.hotwire.turbo.demo.util.BASE_URL
 import dev.hotwire.turbo.nav.TurboNavDestination
-import dev.hotwire.turbo.nav.TurboNavPresentationContext
-import dev.hotwire.turbo.nav.TurboNavPresentationContext.*
+import dev.hotwire.turbo.nav.TurboNavPresentationContext.MODAL
 
 interface NavDestination : TurboNavDestination {
     val menuProgress: MenuItem?

--- a/demo/src/main/kotlin/dev/hotwire/turbo/demo/base/NavDestination.kt
+++ b/demo/src/main/kotlin/dev/hotwire/turbo/demo/base/NavDestination.kt
@@ -1,6 +1,8 @@
 package dev.hotwire.turbo.demo.base
 
 import android.net.Uri
+import android.view.Menu
+import android.view.MenuItem
 import androidx.browser.customtabs.CustomTabColorSchemeParams
 import androidx.browser.customtabs.CustomTabsIntent
 import androidx.browser.customtabs.CustomTabsIntent.SHARE_STATE_ON
@@ -15,6 +17,9 @@ import dev.hotwire.turbo.nav.TurboNavPresentationContext
 import dev.hotwire.turbo.nav.TurboNavPresentationContext.*
 
 interface NavDestination : TurboNavDestination {
+    val menuProgress: MenuItem?
+        get() = toolbarForNavigation()?.menu?.findItem(R.id.menu_progress)
+
     override fun shouldNavigateTo(newLocation: String): Boolean {
         return when (isNavigable(newLocation)) {
             true -> true

--- a/demo/src/main/kotlin/dev/hotwire/turbo/demo/features/web/WebBottomSheetFragment.kt
+++ b/demo/src/main/kotlin/dev/hotwire/turbo/demo/features/web/WebBottomSheetFragment.kt
@@ -1,8 +1,28 @@
 package dev.hotwire.turbo.demo.features.web
 
+import android.os.Bundle
+import android.view.View
+import dev.hotwire.turbo.demo.R
 import dev.hotwire.turbo.demo.base.NavDestination
 import dev.hotwire.turbo.fragments.TurboWebBottomSheetDialogFragment
 import dev.hotwire.turbo.nav.TurboNavGraphDestination
 
 @TurboNavGraphDestination(uri = "turbo://fragment/web/modal/sheet")
-class WebBottomSheetFragment : TurboWebBottomSheetDialogFragment(), NavDestination
+class WebBottomSheetFragment : TurboWebBottomSheetDialogFragment(), NavDestination {
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        setupMenu()
+    }
+
+    override fun onFormSubmissionStarted(location: String) {
+        menuProgress?.isVisible = true
+    }
+
+    override fun onFormSubmissionFinished(location: String) {
+        menuProgress?.isVisible = false
+    }
+
+    private fun setupMenu() {
+        toolbarForNavigation()?.inflateMenu(R.menu.web)
+    }
+}

--- a/demo/src/main/kotlin/dev/hotwire/turbo/demo/features/web/WebFragment.kt
+++ b/demo/src/main/kotlin/dev/hotwire/turbo/demo/features/web/WebFragment.kt
@@ -7,7 +7,6 @@ import dev.hotwire.turbo.demo.base.NavDestination
 import dev.hotwire.turbo.demo.util.SIGN_IN_URL
 import dev.hotwire.turbo.fragments.TurboWebFragment
 import dev.hotwire.turbo.nav.TurboNavGraphDestination
-import dev.hotwire.turbo.visit.TurboVisitAction
 import dev.hotwire.turbo.visit.TurboVisitAction.REPLACE
 import dev.hotwire.turbo.visit.TurboVisitOptions
 

--- a/demo/src/main/kotlin/dev/hotwire/turbo/demo/features/web/WebFragment.kt
+++ b/demo/src/main/kotlin/dev/hotwire/turbo/demo/features/web/WebFragment.kt
@@ -1,5 +1,8 @@
 package dev.hotwire.turbo.demo.features.web
 
+import android.os.Bundle
+import android.view.View
+import dev.hotwire.turbo.demo.R
 import dev.hotwire.turbo.demo.base.NavDestination
 import dev.hotwire.turbo.demo.util.SIGN_IN_URL
 import dev.hotwire.turbo.fragments.TurboWebFragment
@@ -10,10 +13,27 @@ import dev.hotwire.turbo.visit.TurboVisitOptions
 
 @TurboNavGraphDestination(uri = "turbo://fragment/web")
 open class WebFragment : TurboWebFragment(), NavDestination {
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        setupMenu()
+    }
+
+    override fun onFormSubmissionStarted(location: String) {
+        menuProgress?.isVisible = true
+    }
+
+    override fun onFormSubmissionFinished(location: String) {
+        menuProgress?.isVisible = false
+    }
+
     override fun onVisitErrorReceived(location: String, errorCode: Int) {
         when (errorCode) {
             401 -> navigate(SIGN_IN_URL, TurboVisitOptions(action = REPLACE))
             else -> super.onVisitErrorReceived(location, errorCode)
         }
+    }
+
+    private fun setupMenu() {
+        toolbarForNavigation()?.inflateMenu(R.menu.web)
     }
 }

--- a/demo/src/main/res/layout/toolbar_progress.xml
+++ b/demo/src/main/res/layout/toolbar_progress.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="wrap_content"
+    android:layout_height="match_parent">
+
+    <ProgressBar
+        android:layout_width="40dp"
+        android:layout_height="24dp"
+        android:layout_gravity="center"
+        android:layout_marginEnd="12dp"
+        android:indeterminateTint="?colorSecondary" />
+
+</FrameLayout>

--- a/demo/src/main/res/menu/web.xml
+++ b/demo/src/main/res/menu/web.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <item
+        android:id="@+id/menu_progress"
+        android:title="@string/menu_progress"
+        android:visible="false"
+        app:actionLayout="@layout/toolbar_progress"
+        app:showAsAction="always"
+        tools:ignore="AlwaysShowAction" />
+
+</menu>

--- a/demo/src/main/res/values/strings.xml
+++ b/demo/src/main/res/values/strings.xml
@@ -2,4 +2,5 @@
     <string name="app_name">Turbo Native</string>
     <string name="error_web_home">Error loading page</string>
     <string name="error_web_home_description">The demo server may be starting up. Pull-to-refresh to try again in a minute.</string>
+    <string name="menu_progress">Loading…</string>
 </resources>

--- a/turbo/src/main/assets/js/turbo_bridge.js
+++ b/turbo/src/main/assets/js/turbo_bridge.js
@@ -144,6 +144,14 @@
       })
     }
 
+    formSubmissionStarted(formSubmission) {
+      TurboSession.formSubmissionStarted(formSubmission.location.toString())
+    }
+
+    formSubmissionFinished(formSubmission) {
+      TurboSession.formSubmissionFinished(formSubmission.location.toString())
+    }
+
     pageInvalidated() {
       TurboSession.pageInvalidated()
     }

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/config/TurboPathConfigurationRepository.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/config/TurboPathConfigurationRepository.kt
@@ -6,7 +6,6 @@ import androidx.core.content.edit
 import dev.hotwire.turbo.http.TurboHttpClient
 import dev.hotwire.turbo.util.dispatcherProvider
 import dev.hotwire.turbo.util.toJson
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import okhttp3.Request
 import java.io.IOException

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/delegates/TurboWebFragmentDelegate.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/delegates/TurboWebFragmentDelegate.kt
@@ -231,6 +231,14 @@ internal class TurboWebFragmentDelegate(
         return navDestination
     }
 
+    override fun formSubmissionStarted(location: String) {
+        callback.onFormSubmissionStarted(location)
+    }
+
+    override fun formSubmissionFinished(location: String) {
+        callback.onFormSubmissionFinished(location)
+    }
+
     // -----------------------------------------------------------------------
     // Private
     // -----------------------------------------------------------------------

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/fragments/TurboWebFragmentCallback.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/fragments/TurboWebFragmentCallback.kt
@@ -67,6 +67,16 @@ interface TurboWebFragmentCallback {
     fun onVisitErrorReceived(location: String, errorCode: Int) {}
 
     /**
+     * Called when a Turbo form submission has started.
+     */
+    fun onFormSubmissionStarted(location: String) {}
+
+    /**
+     * Called when a Turbo form submission has finished.
+     */
+    fun onFormSubmissionFinished(location: String) {}
+
+    /**
      * Called when the Turbo visit resulted in an error, but a cached
      * snapshot is being displayed, which may be stale.
      */

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/nav/TurboNavRule.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/nav/TurboNavRule.kt
@@ -9,7 +9,6 @@ import dev.hotwire.turbo.config.*
 import dev.hotwire.turbo.session.TurboSessionModalResult
 import dev.hotwire.turbo.visit.TurboVisitAction
 import dev.hotwire.turbo.visit.TurboVisitOptions
-import java.net.URI
 
 @Suppress("MemberVisibilityCanBePrivate")
 internal class TurboNavRule(

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/observers/TurboWindowThemeObserver.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/observers/TurboWindowThemeObserver.kt
@@ -5,7 +5,6 @@ import android.os.Build
 import android.view.View.SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR
 import android.view.View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR
 import android.view.Window
-import android.view.WindowInsetsController
 import android.view.WindowInsetsController.APPEARANCE_LIGHT_STATUS_BARS
 import androidx.annotation.RequiresApi
 import androidx.lifecycle.Lifecycle

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/session/TurboSession.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/session/TurboSession.kt
@@ -355,6 +355,42 @@ class TurboSession internal constructor(
     }
 
     /**
+     * Called by Turbo bridge when a form submission has started.
+     *
+     * Warning: This method is public so it can be used as a Javascript Interface.
+     * You should never call this directly as it could lead to unintended behavior.
+     *
+     * @param location The location of the form submission.
+     */
+    @JavascriptInterface
+    fun formSubmissionStarted(location: String) {
+        logEvent(
+            "formSubmissionStarted",
+            "location" to location
+        )
+
+        callback { it.formSubmissionStarted(location) }
+    }
+
+    /**
+     * Called by Turbo bridge when a form submission has finished.
+     *
+     * Warning: This method is public so it can be used as a Javascript Interface.
+     * You should never call this directly as it could lead to unintended behavior.
+     *
+     * @param location The location of the form submission.
+     */
+    @JavascriptInterface
+    fun formSubmissionFinished(location: String) {
+        logEvent(
+            "formSubmissionFinished",
+            "location" to location
+        )
+
+        callback { it.formSubmissionFinished(location) }
+    }
+
+    /**
      * Called when Turbo bridge detects that the page being visited has been invalidated,
      * typically by new resources in the the page HEAD.
      *

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/session/TurboSession.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/session/TurboSession.kt
@@ -369,7 +369,9 @@ class TurboSession internal constructor(
             "location" to location
         )
 
-        callback { it.formSubmissionStarted(location) }
+        currentVisit?.let {
+            callback { it.formSubmissionStarted(location) }
+        }
     }
 
     /**
@@ -387,7 +389,9 @@ class TurboSession internal constructor(
             "location" to location
         )
 
-        callback { it.formSubmissionFinished(location) }
+        currentVisit?.let {
+            callback { it.formSubmissionFinished(location) }
+        }
     }
 
     /**

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/session/TurboSessionCallback.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/session/TurboSessionCallback.kt
@@ -19,4 +19,6 @@ internal interface TurboSessionCallback {
     fun visitLocationStarted(location: String)
     fun visitProposedToLocation(location: String, options: TurboVisitOptions)
     fun visitNavDestination(): TurboNavDestination
+    fun formSubmissionStarted(location: String)
+    fun formSubmissionFinished(location: String)
 }

--- a/turbo/src/test/kotlin/dev/hotwire/turbo/session/TurboSessionTest.kt
+++ b/turbo/src/test/kotlin/dev/hotwire/turbo/session/TurboSessionTest.kt
@@ -116,6 +116,22 @@ class TurboSessionTest {
     }
 
     @Test
+    fun visitFormSubmissionStartedFiresCallback() {
+        session.currentVisit = visit
+        session.formSubmissionStarted(visit.location)
+
+        verify(callback).formSubmissionStarted(visit.location)
+    }
+
+    @Test
+    fun visitFormSubmissionFinishedFiresCallback() {
+        session.currentVisit = visit
+        session.formSubmissionFinished(visit.location)
+
+        verify(callback).formSubmissionFinished(visit.location)
+    }
+
+    @Test
     fun pageLoadedSavesRestorationIdentifier() {
         val restorationIdentifier = "67890"
         assertThat(session.restorationIdentifiers.size()).isEqualTo(0)


### PR DESCRIPTION
This implements the form submission adapter APIs and allows apps to hook into those callbacks to display form submission progress in their UI.

The demo app has been updated to display a progress indicator in the top right of the toolbar during form submission events:
![2021-09-30 14 13 43](https://user-images.githubusercontent.com/828317/135509956-233045c0-369b-489c-8d05-607106c517f4.png)
