### PR TITLE
docs: Call super in `shouldNavigateTo` override

### DIFF
--- a/docs/NAVIGATION.md
+++ b/docs/NAVIGATION.md
@@ -15,16 +15,11 @@ class WebFragment : TurboWebFragment() {
     // ...
 
     override fun shouldNavigateTo(newLocation: String): Boolean {
-        return when (newLocation.startsWith(MY_DOMAIN)) {
-            true -> {
-                // Allow Turbo to follow the navigation to `newLocation`
-                true
-            }
-            else -> {
-                // Open `newLocation` in the device's external browser
-                launchBrowser(newLocation)
-                false
-            }
+        return if (super.shouldNavigateTo(newLocation) && newLocation.startsWith(MY_DOMAIN)) {
+            true
+        } else {
+            launchBrowser(newLocation)
+            false
         }
     }
 

--- a/docs/NAVIGATION.md
+++ b/docs/NAVIGATION.md
@@ -16,8 +16,10 @@ class WebFragment : TurboWebFragment() {
 
     override fun shouldNavigateTo(newLocation: String): Boolean {
         return if (super.shouldNavigateTo(newLocation) && newLocation.startsWith(MY_DOMAIN)) {
+            // Allow Turbo to follow the navigation to `newLocation`
             true
         } else {
+            // Open `newLocation` in the device's external browser
             launchBrowser(newLocation)
             false
         }


### PR DESCRIPTION
Since https://github.com/hotwired/turbo-android/pull/163, the base implementation of `shouldNavigateTo` is useful because it checks for invalid URLs. So if you override this method we should still recommend you call `super` to get the base implementation.

While here I turned the `when` into an `if` per [this](https://kotlinlang.org/docs/coding-conventions.html#if-versus-when), but I'm certainly not a Kotlin expert and happy to change it back if you prefer.