### PR TITLE
Fix app breaking on cold boot redirects

### DIFF
--- a/turbo/src/main/kotlin/dev/hotwire/turbo/session/TurboSession.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/session/TurboSession.kt
@@ -668,7 +668,7 @@ class TurboSession internal constructor(
                 reset()
             }
 
-            val willProposeThrottledVisit = shouldProposeThrottledVisit()
+            val willProposeThrottledVisit = isColdBootRedirect || shouldProposeThrottledVisit()
             if (shouldOverride && willProposeThrottledVisit) {
                 // Replace the cold boot destination on a redirect
                 // since the original url isn't visitable.

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/session/TurboSession.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/session/TurboSession.kt
@@ -668,8 +668,8 @@ class TurboSession internal constructor(
                 reset()
             }
 
-            val willProposeThrottledVisit = isColdBootRedirect || shouldProposeThrottledVisit()
-            if (shouldOverride && willProposeThrottledVisit) {
+            val willProposeVisit = isColdBootRedirect || shouldProposeThrottledVisit()
+            if (shouldOverride && willProposeVisit) {
                 // Replace the cold boot destination on a redirect
                 // since the original url isn't visitable.
                 val options = when (isColdBootRedirect) {
@@ -683,7 +683,8 @@ class TurboSession internal constructor(
                 "shouldOverrideUrlLoading",
                 "location" to location,
                 "shouldOverride" to shouldOverride,
-                "willProposeThrottledVisit" to willProposeThrottledVisit
+                "isColdBootRedirect" to isColdBootRedirect,
+                "willProposeVisit" to willProposeVisit
             )
 
             return shouldOverride


### PR DESCRIPTION
Fixes https://github.com/hotwired/turbo-android/issues/217

The 500ms delay logic in `shouldOverrideUrlLoading` / `shouldProposeThrottledVisit` is fine for link clicks, but doesn't make sense when following multiple redirects. So this PR just skips that logic while in a cold boot redirect.

See https://github.com/hotwired/turbo-android/issues/217 for more detail on example scenarios and how to replicate. There's another branch ([here](https://github.com/hotwired/turbo-android/compare/main...ghiculescu:slow-redirect)) that you can use to replicate, but I figured I'd keep the fix PR small and if you'd like the extra examples added to the demo I can make followup PRs for that.