### PR TITLE
Multiple modals fix

### DIFF
--- a/turbo/src/main/kotlin/dev/hotwire/turbo/nav/TurboNavigator.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/nav/TurboNavigator.kt
@@ -91,6 +91,7 @@ internal class TurboNavigator(private val navDestination: TurboNavDestination) {
             controller.popBackStack(controller.graph.startDestination, false)
             onCleared()
         }
+        navDestination.delegate().sessionViewModel.modalStackSize = 0
     }
 
     private fun navigateWithinContext(rule: TurboNavRule) {
@@ -138,6 +139,7 @@ internal class TurboNavigator(private val navDestination: TurboNavDestination) {
                 navigateToLocation(rule)
             }
         }
+        navDestination.delegate().sessionViewModel.modalStackSize++
     }
 
     private fun dismissModalContextWithResult(rule: TurboNavRule) {
@@ -189,6 +191,7 @@ internal class TurboNavigator(private val navDestination: TurboNavDestination) {
             "uri" to rule.newDestinationUri
         )
         rule.controller.navigate(rule.newDestination.id, rule.newBundle, rule.newNavOptions)
+        navDestination.delegate().sessionViewModel.modalStackSize = 0
     }
 
     private fun navigateToLocation(rule: TurboNavRule) {
@@ -204,6 +207,13 @@ internal class TurboNavigator(private val navDestination: TurboNavDestination) {
                 "uri" to rule.newDestinationUri
             )
             rule.controller.navigate(it.id, rule.newBundle, rule.newNavOptions, rule.newExtras)
+            if (rule.currentPresentationContext == TurboNavPresentationContext.MODAL) {
+                if (rule.newPresentation == TurboNavPresentation.PUSH) {
+                    navDestination.delegate().sessionViewModel.modalStackSize++
+                } else if (rule.newPresentation == TurboNavPresentation.POP) {
+                    navDestination.delegate().sessionViewModel.modalStackSize--
+                }
+            }
             return
         }
 

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/nav/TurboNavigator.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/nav/TurboNavigator.kt
@@ -157,11 +157,15 @@ internal class TurboNavigator(private val navDestination: TurboNavDestination) {
                 // underlying fragment is still active and will receive the
                 // result immediately. This allows the modal result flow to
                 // behave exactly like full screen fragments.
-                rule.controller.popBackStack(rule.currentDestination.id, true)
+                do {
+                    rule.controller.popBackStack()
+                } while (--navDestination.delegate().sessionViewModel.modalStackSize > 0)
                 sendModalResult(rule)
             } else {
                 sendModalResult(rule)
-                rule.controller.popBackStack(rule.currentDestination.id, true)
+                do {
+                    rule.controller.popBackStack()
+                } while (--navDestination.delegate().sessionViewModel.modalStackSize > 0)
             }
         }
     }

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/session/TurboSessionViewModel.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/session/TurboSessionViewModel.kt
@@ -40,6 +40,14 @@ internal class TurboSessionViewModel : ViewModel() {
     }
 
     /**
+     * A counter to keep track of the number of modals that will need to be dismissed
+     */
+    var modalStackSize: Int = 0
+    set(value) {
+        field = value.coerceAtLeast(0)
+    }
+
+    /**
      * Wraps the visit options in a [TurboSessionEvent] to ensure it can only be consumed once.
      */
     fun saveVisitOptions(options: TurboVisitOptions) {


### PR DESCRIPTION
Fixes #219 

Originally I wanted to walk up the back stack, but it seems like there's a disconnect between the actual destinations (eg: instances of fragments) and the navigation framework's representation of them.