### PR TITLE
Post to the message queue when resetting a NavHostFragment

### DIFF
--- a/turbo/src/main/kotlin/dev/hotwire/turbo/session/TurboSessionNavHostFragment.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/session/TurboSessionNavHostFragment.kt
@@ -47,7 +47,12 @@ abstract class TurboSessionNavHostFragment : NavHostFragment() {
             currentNavDestination.clearBackStack {
                 session.reset()
                 initControllerGraph()
-                onReset()
+
+                if (view == null) {
+                    onReset()
+                } else {
+                    requireView().post { onReset() }
+                }
             }
         }
     }


### PR DESCRIPTION
This works around a bug seen in the Basecamp app where resetting the `NavHostFragment` and then recreating the `Activity` to update its `Theme` would cause the app to crash.