### PR TITLE
Allow multiple modal destinations on the backstack

### DIFF
--- a/turbo/src/main/kotlin/dev/hotwire/turbo/nav/TurboNavRule.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/nav/TurboNavRule.kt
@@ -127,7 +127,7 @@ internal class TurboNavRule(
         val bundle = this ?: bundleOf()
         return bundle.apply {
             putString("location", newLocation)
-            putString("presentation-context", newPresentationContext.name)
+            putSerializable("presentation-context", newPresentationContext)
         }
     }
 

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/nav/TurboNavRule.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/nav/TurboNavRule.kt
@@ -25,16 +25,15 @@ internal class TurboNavRule(
     val currentLocation = checkNotNull(controller.currentBackStackEntry.location)
     val currentProperties = pathConfiguration.properties(currentLocation)
     val currentPresentationContext = currentProperties.context
-    val currentDestination = checkNotNull(controller.currentDestination)
     val isAtStartDestination = controller.previousBackStackEntry == null
 
     // New destination
     val newLocation = location
+    val newProperties = pathConfiguration.properties(newLocation)
+    val newPresentationContext = newProperties.context
     val newVisitOptions = visitOptions
     val newBundle = bundle.withNavArguments()
     val newExtras = extras
-    val newProperties = pathConfiguration.properties(newLocation)
-    val newPresentationContext = newProperties.context
     val newQueryStringPresentation = newProperties.queryStringPresentation
     val newPresentation = newPresentation()
     val newNavigationMode = newNavigationMode()
@@ -126,7 +125,10 @@ internal class TurboNavRule(
 
     private fun Bundle?.withNavArguments(): Bundle {
         val bundle = this ?: bundleOf()
-        return bundle.apply { putString("location", newLocation) }
+        return bundle.apply {
+            putString("location", newLocation)
+            putString("presentation-context", newPresentationContext.name)
+        }
     }
 
     private val NavBackStackEntry?.location: String?

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/nav/TurboNavigator.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/nav/TurboNavigator.kt
@@ -276,9 +276,8 @@ internal class TurboNavigator(private val navDestination: TurboNavDestination) {
 
     private val NavBackStackEntry?.isModalContext: Boolean
         get() = try {
-            val value = this?.arguments?.getString("presentation-context").orEmpty()
-            val context = TurboNavPresentationContext.valueOf(value)
-            context == TurboNavPresentationContext.MODAL
+            val context = this?.arguments?.getSerializable("presentation-context")
+            context as? TurboNavPresentationContext == TurboNavPresentationContext.MODAL
         } catch (e: IllegalArgumentException) {
             false
         }

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/nav/TurboNavigator.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/nav/TurboNavigator.kt
@@ -275,11 +275,9 @@ internal class TurboNavigator(private val navDestination: TurboNavDestination) {
     }
 
     private val NavBackStackEntry?.isModalContext: Boolean
-        get() = try {
+        get() {
             val context = this?.arguments?.getSerializable("presentation-context")
-            context as? TurboNavPresentationContext == TurboNavPresentationContext.MODAL
-        } catch (e: IllegalArgumentException) {
-            false
+            return context as? TurboNavPresentationContext == TurboNavPresentationContext.MODAL
         }
 
     private fun logEvent(event: String, vararg params: Pair<String, Any>) {


### PR DESCRIPTION
Fixes #219 

Properly pop all modal context destinations off the backstack when navigating back to the default context.