### PR TITLE
Replace hardcoded toolbar heights in fragment layouts with wrap_content

### DIFF
--- a/demo/src/main/res/layout/fragment_image_viewer.xml
+++ b/demo/src/main/res/layout/fragment_image_viewer.xml
@@ -11,7 +11,7 @@
     <com.google.android.material.appbar.AppBarLayout
         android:id="@+id/app_bar"
         android:layout_width="match_parent"
-        android:layout_height="56dp"
+        android:layout_height="wrap_content"
         android:stateListAnimator="@null"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
@@ -20,7 +20,7 @@
         <com.google.android.material.appbar.MaterialToolbar
             android:id="@+id/toolbar"
             android:layout_width="match_parent"
-            android:layout_height="match_parent" />
+            android:layout_height="wrap_content" />
 
     </com.google.android.material.appbar.AppBarLayout>
 

--- a/demo/src/main/res/layout/fragment_number_bottom_sheet.xml
+++ b/demo/src/main/res/layout/fragment_number_bottom_sheet.xml
@@ -8,7 +8,7 @@
     <com.google.android.material.appbar.AppBarLayout
         android:id="@+id/app_bar"
         android:layout_width="match_parent"
-        android:layout_height="56dp"
+        android:layout_height="wrap_content"
         android:background="@color/transparent"
         android:stateListAnimator="@null"
         app:layout_constraintTop_toTopOf="parent">
@@ -16,7 +16,7 @@
         <com.google.android.material.appbar.MaterialToolbar
             android:id="@+id/toolbar"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
+            android:layout_height="wrap_content"
             android:background="@color/transparent"/>
 
     </com.google.android.material.appbar.AppBarLayout>

--- a/demo/src/main/res/layout/fragment_numbers.xml
+++ b/demo/src/main/res/layout/fragment_numbers.xml
@@ -8,7 +8,7 @@
     <com.google.android.material.appbar.AppBarLayout
         android:id="@+id/app_bar"
         android:layout_width="match_parent"
-        android:layout_height="56dp"
+        android:layout_height="wrap_content"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent">
@@ -16,7 +16,7 @@
         <com.google.android.material.appbar.MaterialToolbar
             android:id="@+id/toolbar"
             android:layout_width="match_parent"
-            android:layout_height="match_parent" />
+            android:layout_height="wrap_content" />
 
     </com.google.android.material.appbar.AppBarLayout>
 

--- a/demo/src/main/res/layout/fragment_web_home.xml
+++ b/demo/src/main/res/layout/fragment_web_home.xml
@@ -20,7 +20,7 @@
             <com.google.android.material.appbar.MaterialToolbar
                 android:id="@+id/toolbar"
                 android:layout_width="match_parent"
-                android:layout_height="match_parent" />
+                android:layout_height="wrap_content" />
 
             <androidx.appcompat.widget.AppCompatImageView
                 android:id="@+id/app_bar_logo"

--- a/turbo/src/main/res/layout/turbo_fragment_web.xml
+++ b/turbo/src/main/res/layout/turbo_fragment_web.xml
@@ -8,7 +8,7 @@
     <com.google.android.material.appbar.AppBarLayout
         android:id="@+id/app_bar"
         android:layout_width="match_parent"
-        android:layout_height="56dp"
+        android:layout_height="wrap_content"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent">
@@ -16,7 +16,7 @@
         <com.google.android.material.appbar.MaterialToolbar
             android:id="@+id/toolbar"
             android:layout_width="match_parent"
-            android:layout_height="match_parent" />
+            android:layout_height="wrap_content" />
 
     </com.google.android.material.appbar.AppBarLayout>
 

--- a/turbo/src/main/res/layout/turbo_fragment_web_bottom_sheet.xml
+++ b/turbo/src/main/res/layout/turbo_fragment_web_bottom_sheet.xml
@@ -8,14 +8,14 @@
     <com.google.android.material.appbar.AppBarLayout
         android:id="@+id/app_bar"
         android:layout_width="match_parent"
-        android:layout_height="56dp"
+        android:layout_height="wrap_content"
         android:background="@color/transparent"
         android:stateListAnimator="@null">
 
         <com.google.android.material.appbar.MaterialToolbar
             android:id="@+id/toolbar"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
+            android:layout_height="wrap_content"
             android:background="@color/transparent" />
 
     </com.google.android.material.appbar.AppBarLayout>


### PR DESCRIPTION
The hardcoded heights caused toolbar titles or subtitles to be clipped on certain devices or when a non-default font size was selected in the system settings. The heights are now set to `wrap_content`.