### PR TITLE
Avoid edge-case crashes when attaching the webview to the TurboView

### DIFF
--- a/turbo/src/main/kotlin/dev/hotwire/turbo/delegates/TurboWebFragmentDelegate.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/delegates/TurboWebFragmentDelegate.kt
@@ -49,7 +49,7 @@ internal class TurboWebFragmentDelegate(
         get() = navDestination.delegate().navigator
     private val turboView: TurboView?
         get() = callback.turboView
-    private val viewLifecycleOwner
+    private val viewTreeLifecycleOwner
         get() = turboView?.findViewTreeLifecycleOwner()
 
     /**
@@ -350,13 +350,13 @@ internal class TurboWebFragmentDelegate(
             else -> visitOptions
         }
 
-        viewLifecycleOwner?.lifecycleScope?.launch {
+        viewTreeLifecycleOwner?.lifecycleScope?.launch {
             val snapshot = when (options.action) {
                 TurboVisitAction.ADVANCE -> fetchCachedSnapshot()
                 else -> null
             }
 
-            viewLifecycleOwner?.lifecycle?.whenStateAtLeast(STARTED) {
+            viewTreeLifecycleOwner?.lifecycle?.whenStateAtLeast(STARTED) {
                 session().visit(
                     TurboVisit(
                         location = location,

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/delegates/TurboWebFragmentDelegate.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/delegates/TurboWebFragmentDelegate.kt
@@ -6,6 +6,7 @@ import android.webkit.HttpAuthHandler
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts.StartActivityForResult
 import androidx.lifecycle.Lifecycle.State.STARTED
+import androidx.lifecycle.findViewTreeLifecycleOwner
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.whenStateAtLeast
 import dev.hotwire.turbo.config.pullToRefreshEnabled
@@ -49,7 +50,7 @@ internal class TurboWebFragmentDelegate(
     private val turboView: TurboView?
         get() = callback.turboView
     private val viewLifecycleOwner
-        get() = navDestination.fragment.viewLifecycleOwner
+        get() = turboView?.findViewTreeLifecycleOwner()
 
     /**
      * Get the session's WebView instance
@@ -349,13 +350,13 @@ internal class TurboWebFragmentDelegate(
             else -> visitOptions
         }
 
-        viewLifecycleOwner.lifecycleScope.launch {
+        viewLifecycleOwner?.lifecycleScope?.launch {
             val snapshot = when (options.action) {
                 TurboVisitAction.ADVANCE -> fetchCachedSnapshot()
                 else -> null
             }
 
-            viewLifecycleOwner.lifecycle.whenStateAtLeast(STARTED) {
+            viewLifecycleOwner?.lifecycle?.whenStateAtLeast(STARTED) {
                 session().visit(
                     TurboVisit(
                         location = location,

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/views/TurboView.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/views/TurboView.kt
@@ -42,8 +42,14 @@ class TurboView @JvmOverloads constructor(context: Context, attrs: AttributeSet?
         }
 
         webViewContainer.post {
-            webViewContainer.addView(webView)
-            onAttachedToNewDestination(true)
+            // To avoid edge-case lifecycle issues, ensure that the
+            // view is still attached to the window and the webview
+            // doesn't have a new parent, since we have no control
+            // over the message queue.
+            if (isAttachedToWindow && webView.parent == null) {
+                webViewContainer.addView(webView)
+                onAttachedToNewDestination(true)
+            }
         }
     }
 


### PR DESCRIPTION
This seeks to resolve two crashes that are difficult to reproduce.

This was introduced in #236:
```
java.lang.IllegalStateException: Can't access the Fragment View's LifecycleOwner when getView() is null i.e., before onCreateView() or after onDestroyView()
    at androidx.fragment.app.Fragment.getViewLifecycleOwner(SourceFile:361)
    at dev.hotwire.turbo.delegates.TurboWebFragmentDelegate.getViewLifecycleOwner
    at dev.hotwire.turbo.delegates.TurboWebFragmentDelegate.visit
    at dev.hotwire.turbo.delegates.TurboWebFragmentDelegate.access$visit
    at dev.hotwire.turbo.delegates.TurboWebFragmentDelegate$attachWebViewAndVisit$1.invoke
    at dev.hotwire.turbo.delegates.TurboWebFragmentDelegate$attachWebViewAndVisit$1.invoke
    at dev.hotwire.turbo.delegates.TurboWebFragmentDelegate$attachWebView$2.invoke
    at dev.hotwire.turbo.delegates.TurboWebFragmentDelegate$attachWebView$2.invoke
    at dev.hotwire.turbo.views.TurboView$attachWebView$1.run
    at android.os.Handler.handleCallback(Handler.java:938)
    at android.os.Handler.dispatchMessage(Handler.java:99)
    at android.os.Looper.loopOnce(Looper.java:226)
    at android.os.Looper.loop(Looper.java:313)
    at android.app.ActivityThread.main(ActivityThread.java:8663)
    at java.lang.reflect.Method.invoke(Method.java)
    at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:567)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1135)
```

This has existed for a quite awhile:
```
java.lang.IllegalStateException: The specified child already has a parent. You must call removeView() on the child's parent first.
    at android.view.ViewGroup.addViewInner(ViewGroup.java:6065)
    at android.view.ViewGroup.addView(ViewGroup.java:5884)
    at android.view.ViewGroup.addView(ViewGroup.java:5824)
    at android.view.ViewGroup.addView(ViewGroup.java:5796)
    at dev.hotwire.turbo.views.TurboView$attachWebView$1.run
    at android.os.Handler.handleCallback(Handler.java:938)
    at android.os.Handler.dispatchMessage(Handler.java:99)
    at android.os.Looper.loop(Looper.java:246)
    at android.app.ActivityThread.main(ActivityThread.java:8538)
    at java.lang.reflect.Method.invoke(Method.java)
    at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:602)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1130)
```