### PR TITLE
Allow clear text traffic in debug build

### DIFF
--- a/demo/src/debug/AndroidManifest.xml
+++ b/demo/src/debug/AndroidManifest.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:tools="http://schemas.android.com/tools"
+    package="dev.hotwire.turbo.demo"
+    xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application
+        android:usesCleartextTraffic="true">
+    </application>
+
+</manifest>


### PR DESCRIPTION
Hi. I'm trying to learn how turbo-android should work, so I cloned this repo and the [turbo-native-demo](https://github.com/hotwired/turbo-native-demo) repo. I was able to start the android app on an emulator and it loaded the content from the official site. Perfect :)

Then I made this change to hook it up with my local clone of `turbo-native-demo`:

```diff
diff --git a/demo/src/main/kotlin/dev/hotwire/turbo/demo/util/Constants.kt b/demo/src/main/kotlin/dev/hotwire/turbo/
demo/util/Constants.kt
index 1be473e..dfdabb3 100644
--- a/demo/src/main/kotlin/dev/hotwire/turbo/demo/util/Constants.kt
+++ b/demo/src/main/kotlin/dev/hotwire/turbo/demo/util/Constants.kt
@@ -1,6 +1,6 @@
 package dev.hotwire.turbo.demo.util

-const val BASE_URL = "https://turbo-native-demo.glitch.me"
+const val BASE_URL = "http://10.0.2.2:45678"
 const val HOME_URL = BASE_URL
 const val SIGN_IN_URL = "$BASE_URL/signin"
 const val NUMBERS_URL = "$BASE_URL/numbers"
```

Unfortunately it did not work. I checked loading the local server from a browser on the emulator and it loaded everything, so I opened up `adb logcat` to investigate what's happening and found this pattern:

```
08-20 16:49:05.462 14279 14279 D TurboLog: visitLocationAsColdBoot ........... [session: main, location: http://10.0.2.2:45678]
08-20 16:49:05.492 14279 14279 D TurboLog: onPageStarted ..................... [session: main, location: http://10.0.2.2:45678/]
08-20 16:49:05.493 14279 14279 D TurboLog: onReceivedError ................... [session: main, errorCode: -1]
08-20 16:49:05.493 14279 14279 D TurboLog: reset ............................. [session: main]
08-20 16:49:05.611 14279 14279 D TurboLog: onPageCommitVisible ............... [session: main, location: http://10.0.2.2:45678/, progress: 100]
```

Finally I found that the error description is `net::ERR_CLEARTEXT_NOT_PERMITTED` which could happen if you try to load an unencrypted plain text without the proper permissions ([docs](https://developer.android.com/guide/topics/manifest/application-element#usesCleartextTraffic)). I added the missing permission to the debug build type and it fixed it immediately. (I don't think we should add this permission to the release build type to encourage a more secure setup in the demo app.)

I hope this PR helps others to become familiar with this cool project easier :)