### PR TITLE
Expose TurboSession allowing use outside the module

### DIFF
--- a/turbo/src/main/kotlin/dev/hotwire/turbo/session/TurboSessionCallback.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/session/TurboSessionCallback.kt
@@ -4,7 +4,7 @@ import android.webkit.HttpAuthHandler
 import dev.hotwire.turbo.nav.TurboNavDestination
 import dev.hotwire.turbo.visit.TurboVisitOptions
 
-internal interface TurboSessionCallback {
+interface TurboSessionCallback {
     fun onPageStarted(location: String)
     fun onPageFinished(location: String)
     fun onReceivedError(errorCode: Int)

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/views/TurboView.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/views/TurboView.kt
@@ -27,10 +27,10 @@ class TurboView @JvmOverloads constructor(context: Context, attrs: AttributeSet?
     private val errorContainer: ViewGroup get() = findViewById(R.id.turbo_error_container)
     private val screenshotView: ImageView get() = findViewById(R.id.turbo_screenshot)
 
-    internal val webViewRefresh: SwipeRefreshLayout? get() = webViewContainer as? SwipeRefreshLayout
-    internal val errorRefresh: SwipeRefreshLayout? get() = findViewById(R.id.turbo_error_refresh)
+    val webViewRefresh: SwipeRefreshLayout? get() = webViewContainer as? SwipeRefreshLayout
+    val errorRefresh: SwipeRefreshLayout? get() = findViewById(R.id.turbo_error_refresh)
 
-    internal fun attachWebView(webView: WebView, onAttachedToNewDestination: (Boolean) -> Unit) {
+    fun attachWebView(webView: WebView, onAttachedToNewDestination: (Boolean) -> Unit) {
         if (webView.parent != null) {
             onAttachedToNewDestination(false)
             return
@@ -53,7 +53,7 @@ class TurboView @JvmOverloads constructor(context: Context, attrs: AttributeSet?
         }
     }
 
-    internal fun detachWebView(webView: WebView, onDetached: () -> Unit) {
+    fun detachWebView(webView: WebView, onDetached: () -> Unit) {
         // If the view is already detached from the window (like
         // when dismissing a bottom sheet), detach immediately,
         // since posting to the message queue will be ignored.
@@ -72,7 +72,7 @@ class TurboView @JvmOverloads constructor(context: Context, attrs: AttributeSet?
         return webViewContainer.contains(webView)
     }
 
-    internal fun addProgressView(progressView: View) {
+    fun addProgressView(progressView: View) {
         // Don't show the progress view if a screenshot is available
         if (screenshotView.isVisible) return
 
@@ -83,19 +83,19 @@ class TurboView @JvmOverloads constructor(context: Context, attrs: AttributeSet?
         progressContainer.isVisible = true
     }
 
-    internal fun removeProgressView() {
+    fun removeProgressView() {
         progressContainer.removeAllViews()
         progressContainer.isVisible = false
     }
 
-    internal fun addScreenshot(screenshot: Bitmap?) {
+    fun addScreenshot(screenshot: Bitmap?) {
         if (screenshot == null) return
 
         screenshotView.setImageBitmap(screenshot)
         screenshotView.isVisible = true
     }
 
-    internal fun removeScreenshot() {
+    fun removeScreenshot() {
         screenshotView.setImageBitmap(null)
         screenshotView.isVisible = false
     }
@@ -114,7 +114,7 @@ class TurboView @JvmOverloads constructor(context: Context, attrs: AttributeSet?
         }
     }
 
-    internal fun removeErrorView() {
+    fun removeErrorView() {
         errorContainer.removeAllViews()
         errorContainer.isVisible = false
 
@@ -125,7 +125,7 @@ class TurboView @JvmOverloads constructor(context: Context, attrs: AttributeSet?
         }
     }
 
-    internal fun createScreenshot(): Bitmap? {
+    fun createScreenshot(): Bitmap? {
         if (!isLaidOut) return null
         if (!hasEnoughMemoryForScreenshot()) return null
         if (width <= 0 || height <= 0) return null
@@ -138,7 +138,7 @@ class TurboView @JvmOverloads constructor(context: Context, attrs: AttributeSet?
         }
     }
 
-    internal fun screenshotOrientation(): Int {
+    fun screenshotOrientation(): Int {
         return context.resources.configuration.orientation
     }
 

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/visit/TurboVisit.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/visit/TurboVisit.kt
@@ -2,7 +2,7 @@ package dev.hotwire.turbo.visit
 
 import dev.hotwire.turbo.session.TurboSessionCallback
 
-internal data class TurboVisit(
+data class TurboVisit(
     val location: String,
     val destinationIdentifier: Int,
     val restoreWithCachedSnapshot: Boolean,


### PR DESCRIPTION
Fixes: #245 

## Summary

Hello 👋 I am software engineer working for [Software Mansion](https://github.com/software-mansion). Together with @pfeiffer we are working on React Native support for Turbo 🚀. Our goal is to add support for React Native hybrid apps on both iOS and Android for turbo enabled websites. Under the hood we use both [Turbo Android](https://github.com/hotwired/turbo-android) and [Turbo iOS](https://github.com/hotwired/turbo-ios). We have an almost ready version of our library, please check out our repo [react-native-turbo-webview](https://github.com/software-mansion-labs/react-native-turbo-demo).

## What's the problem?

iOS implementation with [Turbo iOS](https://github.com/hotwired/turbo-ios) was fairly easy, but the way Turbo Android depends on `Android Navigation`, makes the Android-implementation less straightforward.
​
[Turbo Android](https://github.com/hotwired/turbo-android) doesn't leave much freedom for our implementation and It is impossible to use it without the [Android Navigation](https://developer.android.com/guide/navigation) which we can't use in the case of React Native. We are forced to use session class directly, sadly it is not easy as it is marked with `internal` visibility modifiers. 
​
We solved this problem in forked repo, at the moment we are using a patched version of `turbo-android` for the PoC.
​
Removing `internal` modifiers makes it possible to use the package similarly to [Turbo iOS](https://github.com/hotwired/turbo-ios) and unifies the API. I do not see any reasons against the removal of modifiers but I am open to discussion over alternative solutions.

## Changes

- The PR removes several Kotlin internal visibility modifiers and makes `TurboSession` class accessible beyond module scope.
- Adds `isRunningInAndroidNavigation` property (with default `true`) and changes one if statement condition. Does not change anything in the method when `isRunningInAndroidNavigation` is false so it won't affect non React-Native users.
