### PR TITLE
Prevent path traversal vulnerability in TurboUriHelper

### DIFF
--- a/turbo/src/main/kotlin/dev/hotwire/turbo/util/TurboUriHelper.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/util/TurboUriHelper.kt
@@ -15,9 +15,8 @@ internal class TurboUriHelper(val context: Context) {
         val uriAttributes = getAttributes(uri) ?: return null
 
         return withContext(dispatcherProvider.io) {
-            val file = File(destDirectory, uriAttributes.fileName)
-
             try {
+                val file = File(destDirectory, uriAttributes.fileName)
                 file.checkForPathTraversalVulnerability(destDirectory)
 
                 if (file.exists()) {

--- a/turbo/src/test/kotlin/dev/hotwire/turbo/util/TurboUriHelperTest.kt
+++ b/turbo/src/test/kotlin/dev/hotwire/turbo/util/TurboUriHelperTest.kt
@@ -1,0 +1,79 @@
+package dev.hotwire.turbo.util
+
+import android.content.Context
+import android.net.Uri
+import android.os.Build
+import androidx.test.core.app.ApplicationProvider
+import dev.hotwire.turbo.BaseUnitTest
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestCoroutineDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows
+import org.robolectric.annotation.Config
+import java.io.File
+
+@ExperimentalCoroutinesApi
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Build.VERSION_CODES.O])
+class TurboUriHelperTest : BaseUnitTest() {
+
+    private val testDispatcher: TestCoroutineDispatcher = TestCoroutineDispatcher()
+
+    private lateinit var context: Context
+    private lateinit var turboUriHelper: TurboUriHelper
+
+    @Before
+    override fun setup() {
+        super.setup()
+        Dispatchers.setMain(testDispatcher)
+        dispatcherProvider.io = Dispatchers.Main
+
+        context = ApplicationProvider.getApplicationContext()
+        turboUriHelper = TurboUriHelper(context)
+    }
+
+    override fun teardown() {
+        super.teardown()
+        Dispatchers.resetMain()
+        testDispatcher.cleanupTestCoroutines()
+    }
+
+    @Test
+    fun validUriIsWrittenToFileSuccessfully() = runTest {
+        val inputFile = File("/tmp/file.txt")
+        val inputFileUri = Uri.fromFile(inputFile)
+        Shadows.shadowOf(context.contentResolver).registerInputStream(inputFileUri, "fileContent".byteInputStream())
+
+        val destFile = turboUriHelper.writeFileTo(inputFileUri, TurboFileProvider.directory(context))
+
+        assertThat(destFile).isNotNull()
+    }
+
+    @Test
+    fun pathTraversingUriIsFailsToWriteToFileV1() = runTest {
+        val inputFileUri = Uri.parse("../../tmp/file.txt")
+        Shadows.shadowOf(context.contentResolver).registerInputStream(inputFileUri, "fileContent".byteInputStream())
+
+        val destFile = turboUriHelper.writeFileTo(inputFileUri, TurboFileProvider.directory(context))
+
+        assertThat(destFile).isNull()
+    }
+
+    @Test
+    fun pathTraversingUriIsFailsToWriteToFileV2() = runTest {
+        val inputFileUri = Uri.parse("content://malicious.app?path=/data/data/malicious.app/files/file.txt&name=../../file.txt")
+        Shadows.shadowOf(context.contentResolver).registerInputStream(inputFileUri, "fileContent".byteInputStream())
+
+        val destFile = turboUriHelper.writeFileTo(inputFileUri, TurboFileProvider.directory(context))
+
+        assertThat(destFile).isNull()
+    }
+}

--- a/turbo/src/test/kotlin/dev/hotwire/turbo/util/TurboUriHelperTest.kt
+++ b/turbo/src/test/kotlin/dev/hotwire/turbo/util/TurboUriHelperTest.kt
@@ -58,7 +58,7 @@ class TurboUriHelperTest : BaseUnitTest() {
     }
 
     @Test
-    fun pathTraversingUriIsFailsToWriteToFileV1() = runTest {
+    fun pathTraversingUriWithRelativePathFailsToWriteToFile() = runTest {
         val inputFileUri = Uri.parse("../../tmp/file.txt")
         Shadows.shadowOf(context.contentResolver).registerInputStream(inputFileUri, "fileContent".byteInputStream())
 
@@ -68,7 +68,7 @@ class TurboUriHelperTest : BaseUnitTest() {
     }
 
     @Test
-    fun pathTraversingUriIsFailsToWriteToFileV2() = runTest {
+    fun pathTraversingUriWithNameArgFailsToWriteToFile() = runTest {
         val inputFileUri = Uri.parse("content://malicious.app?path=/data/data/malicious.app/files/file.txt&name=../../file.txt")
         Shadows.shadowOf(context.contentResolver).registerInputStream(inputFileUri, "fileContent".byteInputStream())
 


### PR DESCRIPTION
This PR adds checks for a [path traversal attacks](https://developer.android.com/topic/security/risks/path-traversal).

A malicious app can inject URIs of files with file names containing characters such as "../" that when resolved cause the file to be written to parent directories and even rewrite content of existing files.

The changes in this PR prevent this.