### PR TITLE
Add correct MIME type "image/jpeg" on image capture for file uploads

### DIFF
--- a/turbo/src/main/kotlin/dev/hotwire/turbo/delegates/TurboCameraCaptureDelegate.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/delegates/TurboCameraCaptureDelegate.kt
@@ -56,7 +56,7 @@ internal class TurboCameraCaptureDelegate(val context: Context) {
     private fun FileChooserParams.allowsCameraCapture(): Boolean {
         val accept = defaultAcceptType()
         val acceptsAny = accept == "*/*"
-        val acceptsImages = accept == "image/*" || accept == "image/jpg"
+        val acceptsImages = accept == "image/*" || accept == "image/jpg" || accept == "image/jpeg"
 
         return isCaptureEnabled && (acceptsAny || acceptsImages)
     }


### PR DESCRIPTION
#141 is an awesome feature but was not working out of the gate. I was not using `"image/*"` and saw that `"image/jpg"` was also set for accept but since I had `"image/jpeg"` it didn't work right away. There is no MIME type `"image/jpg"` and the actual type is `"image/jpeg"`. This commit adds the correct MIME type while keeping `"image/jpg"` for anyone that used that with this feature. It'd probably be good to add more common image types in the future.