### PR TITLE
Fix WebView scrolling in BottomSheet

### DIFF
--- a/turbo/src/main/kotlin/dev/hotwire/turbo/views/TurboWebView.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/views/TurboWebView.kt
@@ -6,6 +6,7 @@ import android.util.AttributeSet
 import android.webkit.WebView
 import android.widget.FrameLayout
 import android.widget.FrameLayout.LayoutParams.MATCH_PARENT
+import android.widget.FrameLayout.LayoutParams.WRAP_CONTENT
 import androidx.webkit.WebViewCompat
 import dev.hotwire.turbo.util.contentFromAsset
 import dev.hotwire.turbo.util.runOnUiThread
@@ -28,7 +29,7 @@ open class TurboWebView @JvmOverloads constructor(context: Context, attrs: Attri
         settings.javaScriptEnabled = true
         settings.domStorageEnabled = true
         settings.setSupportMultipleWindows(true)
-        layoutParams = FrameLayout.LayoutParams(MATCH_PARENT, MATCH_PARENT)
+        layoutParams = FrameLayout.LayoutParams(MATCH_PARENT, WRAP_CONTENT)
     }
 
     /**

--- a/turbo/src/main/res/layout/turbo_view.xml
+++ b/turbo/src/main/res/layout/turbo_view.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<dev.hotwire.turbo.views.TurboView
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<dev.hotwire.turbo.views.TurboView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/turbo_view"
     android:layout_width="match_parent"
@@ -9,7 +8,8 @@
     <dev.hotwire.turbo.views.TurboSwipeRefreshLayout
         android:id="@+id/turbo_webView_container"
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="match_parent"
+        android:fillViewport="true">
 
         <!-- WebView get attached/detached here -->
 
@@ -19,9 +19,9 @@
         android:id="@+id/turbo_progress_container"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:visibility="gone"
         android:clickable="true"
-        android:focusable="true">
+        android:focusable="true"
+        android:visibility="gone">
 
         <!-- Custom progress view added/removed here -->
 
@@ -31,19 +31,20 @@
         android:id="@+id/turbo_screenshot"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:visibility="gone"
         android:clickable="true"
         android:focusable="true"
         android:scaleType="fitStart"
+        android:visibility="gone"
         tools:ignore="ContentDescription" />
 
     <dev.hotwire.turbo.views.TurboSwipeRefreshLayout
         android:id="@+id/turbo_error_refresh"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:visibility="gone"
         android:clickable="true"
-        android:focusable="true">
+        android:fillViewport="true"
+        android:focusable="true"
+        android:visibility="gone">
 
         <ScrollView
             android:id="@+id/turbo_error_container"

--- a/turbo/src/main/res/layout/turbo_view_bottom_sheet.xml
+++ b/turbo/src/main/res/layout/turbo_view_bottom_sheet.xml
@@ -6,15 +6,16 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <FrameLayout
+    <androidx.core.widget.NestedScrollView
         android:id="@+id/turbo_webView_container"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:fillViewport="true"
         android:minHeight="400dp">
 
         <!-- WebView get attached/detached here -->
 
-    </FrameLayout>
+    </androidx.core.widget.NestedScrollView>
 
     <FrameLayout
         android:id="@+id/turbo_progress_container"


### PR DESCRIPTION
This PR updates the layout of `TurboWebBottomSheetDialogFragment` to enable nested scrolling of a `WebView` in `BottomSheet`.

| Before (no nested scrolling) | After (nested scrolling) |
| -------------------------- | ------------------------ |
| ![before](https://user-images.githubusercontent.com/2276150/224965349-7387b596-fe24-4eb0-89a7-c4227dc9f53d.gif)  | ![after](https://user-images.githubusercontent.com/2276150/224965385-2b203bd1-68c3-4ac1-ae6d-a64f0ac64def.gif)  |