### PR TITLE
Suppress Glide lint error

### DIFF
--- a/demo/android-lint.xml
+++ b/demo/android-lint.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- https://github.com/bumptech/glide/issues/4940 -->
+<lint>
+    <issue id="NotificationPermission">
+        <ignore regexp="com.bumptech.glide.request.target.NotificationTarget" />
+    </issue>
+</lint>
+

--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -39,6 +39,11 @@ android {
         test.java.srcDirs += 'src/test/kotlin'
         debug.java.srcDirs += 'src/debug/kotlin'
     }
+
+    lint {
+        lintConfig = file("android-lint.xml")
+    }
+
     namespace 'dev.hotwire.turbo.demo'
 }
 
@@ -46,9 +51,9 @@ dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     implementation 'com.google.android.material:material:1.8.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
-    implementation 'androidx.recyclerview:recyclerview:1.2.1'
+    implementation 'androidx.recyclerview:recyclerview:1.3.0'
     implementation 'androidx.browser:browser:1.5.0'
-    implementation 'com.github.bumptech.glide:glide:4.14.2'
+    implementation 'com.github.bumptech.glide:glide:4.15.1'
 
     implementation project(':turbo')
 }


### PR DESCRIPTION
Latest Android gradle plugin introduced a new lint rule which fails for the demo app due to Glide providing a `NotificationTarget`:

```
When targeting Android 13 or higher, posting a permission requires holding the POST_NOTIFICATIONS permission (usage from com.bumptech.glide.request.target.NotificationTarget) [NotificationPermission]
  
     Explanation for issues of type "NotificationPermission":
     When targeting Android 13 and higher, posting permissions requires holding
     the runtime permission android.permission.POST_NOTIFICATIONS.
```

More information: https://github.com/bumptech/glide/issues/4940

This PR adds a lint config for the demo module which suppresses it as we never post notifications from it.