### PR TITLE
Simplify TurboVisitResponse in debug logs

### DIFF
--- a/turbo/src/main/kotlin/dev/hotwire/turbo/visit/TurboVisitResponse.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/visit/TurboVisitResponse.kt
@@ -5,4 +5,8 @@ import com.google.gson.annotations.SerializedName
 data class TurboVisitResponse(
     @SerializedName("statusCode") val statusCode: Int,
     @SerializedName("responseHTML") val responseHTML: String? = null
-)
+) {
+    override fun toString(): String {
+        return "TurboVisitResponse(responseCode: $statusCode responseLength: ${responseHTML?.length})"
+    }
+}


### PR DESCRIPTION
Not showing the full HTML in the logs, which makes them tricky to read.

From:

    options: TurboVisitOptions(action=ADVANCE, snapshotHTML=null, response=TurboVisitResponse(statusCode=200, responseHTML=<!DOCTYPE html>
        <html class='h-full' lang='en'>
        <head>
        <meta charset='UTF-8'>
        ...snip...
        </body>
        </html>
        ))]

To:

    options: TurboVisitOptions(action=ADVANCE, snapshotHTML=null, response=TurboVisitResponse<responseCode: 200 responseLength: 30831>)