### PR TITLE
Set WebView's height to wrap content if its parent is ScrollingView

### DIFF
--- a/turbo/src/main/kotlin/dev/hotwire/turbo/views/TurboView.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/views/TurboView.kt
@@ -9,9 +9,7 @@ import android.view.ViewGroup
 import android.webkit.WebView
 import android.widget.FrameLayout
 import android.widget.ImageView
-import androidx.core.view.contains
-import androidx.core.view.drawToBitmap
-import androidx.core.view.isVisible
+import androidx.core.view.*
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import dev.hotwire.turbo.R
 
@@ -34,6 +32,13 @@ class TurboView @JvmOverloads constructor(context: Context, attrs: AttributeSet?
         if (webView.parent != null) {
             onAttachedToNewDestination(false)
             return
+        }
+
+        webView.updateLayoutParams {
+            height = when (webViewContainer) {
+                is ScrollingView -> LayoutParams.WRAP_CONTENT
+                else -> LayoutParams.MATCH_PARENT
+            }
         }
 
         // Match the WebView background with its new parent

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/views/TurboWebView.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/views/TurboWebView.kt
@@ -29,7 +29,7 @@ open class TurboWebView @JvmOverloads constructor(context: Context, attrs: Attri
         settings.javaScriptEnabled = true
         settings.domStorageEnabled = true
         settings.setSupportMultipleWindows(true)
-        layoutParams = FrameLayout.LayoutParams(MATCH_PARENT, WRAP_CONTENT)
+        layoutParams = FrameLayout.LayoutParams(MATCH_PARENT, MATCH_PARENT)
     }
 
     /**

--- a/turbo/src/test/kotlin/dev/hotwire/turbo/views/TurboViewTest.kt
+++ b/turbo/src/test/kotlin/dev/hotwire/turbo/views/TurboViewTest.kt
@@ -5,7 +5,9 @@ import android.os.Build
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import android.webkit.WebView
+import android.widget.FrameLayout.LayoutParams
 import androidx.test.core.app.ApplicationProvider
+import com.nhaarman.mockito_kotlin.whenever
 import dev.hotwire.turbo.R
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
@@ -30,6 +32,10 @@ class TurboViewTest {
         context = ApplicationProvider.getApplicationContext()
         view = LayoutInflater.from(context).inflate(R.layout.turbo_view, null) as ViewGroup
         turboView = view.findViewById(R.id.turbo_view)
+
+        whenever(webView.layoutParams).thenReturn(
+            LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT)
+        )
     }
 
     @Test fun refreshLayoutIsFirstChild() {


### PR DESCRIPTION
The change to support proper nested scrolling of a WebView inside of a BottomSheet introduced in https://github.com/hotwired/turbo-android/pull/261 unfortunately caused some side-effects to other full-height screens in some cases related to scrolling of nested content.

Therefore, this PR restores the default layout parameters of the shared WebView to `MatchParent` and only if the WebView's parent is `ScrollingView`, its height is set to `WrapContent`.