### PR TITLE
Prevent web page screenshot scaling down in some cases

### DIFF
--- a/turbo/src/main/res/layout/turbo_view.xml
+++ b/turbo/src/main/res/layout/turbo_view.xml
@@ -33,7 +33,7 @@
         android:layout_height="match_parent"
         android:clickable="true"
         android:focusable="true"
-        android:scaleType="fitStart"
+        android:scaleType="matrix"
         android:visibility="gone"
         tools:ignore="ContentDescription" />
 

--- a/turbo/src/main/res/layout/turbo_view_bottom_sheet.xml
+++ b/turbo/src/main/res/layout/turbo_view_bottom_sheet.xml
@@ -37,7 +37,7 @@
         android:visibility="gone"
         android:clickable="true"
         android:focusable="true"
-        android:scaleType="fitStart"
+        android:scaleType="matrix"
         tools:ignore="ContentDescription" />
 
     <FrameLayout


### PR DESCRIPTION
Fixes #206:

> ... when you have an input field in a bottom modal sheet and you focus on it to type, the viewport for the page behind the modal shrinks a bit ...

It does so by changing the scaleType of the ImageView that holds a screenshot of a detached WebView page to [`matrix`](https://developer.android.com/reference/android/widget/ImageView#setImageMatrix(android.graphics.Matrix)). Not setting any value programmatically leaves the image unchanged even when the height of the ImageView changes (due to the keyboard popping up).