### PR TITLE
Support Android 13's predictive back gesture

### DIFF
--- a/demo/src/main/AndroidManifest.xml
+++ b/demo/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
 
     <application
         android:allowBackup="false"
+        android:enableOnBackInvokedCallback="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"

--- a/turbo/build.gradle
+++ b/turbo/build.gradle
@@ -95,7 +95,8 @@ dependencies {
     api 'androidx.appcompat:appcompat:1.6.1'
     api 'androidx.core:core-ktx:1.9.0'
     api 'androidx.webkit:webkit:1.6.0'
-    api 'androidx.fragment:fragment-ktx:1.5.5'
+    api 'androidx.activity:activity-ktx:1.7.1'
+    api 'androidx.fragment:fragment-ktx:1.5.7'
     api 'androidx.navigation:navigation-fragment-ktx:2.5.3'
     api 'androidx.navigation:navigation-ui-ktx:2.5.3'
 

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/nav/TurboNavigator.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/nav/TurboNavigator.kt
@@ -4,7 +4,6 @@ import android.os.Bundle
 import androidx.fragment.app.DialogFragment
 import androidx.navigation.NavBackStackEntry
 import androidx.navigation.NavController
-import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavOptions
 import androidx.navigation.fragment.FragmentNavigator
 import androidx.navigation.fragment.findNavController
@@ -29,9 +28,7 @@ internal class TurboNavigator(private val navDestination: TurboNavDestination) {
 
     fun navigateBack() {
         onNavigationVisit {
-            if (!currentController().popBackStack()) {
-                fragment.requireActivity().finish()
-            }
+            currentController().popBackStack()
         }
     }
 


### PR DESCRIPTION
This allows the library's navigation to respect Android 13/14's new predictive back gesture. Documentation: https://developer.android.com/guide/navigation/predictive-back-gesture

This disable the `Activity`'s `OnBackPressedCallback` when the current nav controller is at its start destination. This allows the system to take control over the back behavior when leaving the app and display a custom animation.

Even if a particular user doesn't not have the "Preditive back animations" Developer Option enabled in Android 13, this change still provides a tangible benefit. The app's main Activity will no longer `.finish()` when using the back gesture/button to leave the app. For the first time, Android 13 maintains the `Activity` instance if an app does not manually call `.finish()`.

On Android 13, apps that want to opt into the predictive back gesture must enable the following `AndroidManifest` flag:
```xml
<application
    ...
    android:enableOnBackInvokedCallback="true">
```
-------------------

_Note that Android 14 will further expand on the predictive back gesture including between screens, but the `AndroidX` APIs are not finalized and it requires targeting SDK `34`, which hasn't hit API stability yet._