### PR TITLE
Improve how a TurboVisitResponse is logged

### DIFF
--- a/turbo/src/main/kotlin/dev/hotwire/turbo/util/TurboExtensions.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/util/TurboExtensions.kt
@@ -31,6 +31,20 @@ internal fun String.extract(patternRegex: String): String? {
     return regex.find(this)?.groups?.get(1)?.value
 }
 
+internal fun String.truncateMiddle(maxChars: Int): String {
+    if (maxChars <= 1 || length <= maxChars) { return this }
+
+    return "${take(maxChars / 2)} [...] ${takeLast(maxChars / 2)}"
+}
+
+internal fun String.withoutNewLineChars(): String {
+    return this.replace("\n", "")
+}
+
+internal fun String.withoutRepeatingWhitespace(): String {
+    return this.replace(Regex("\\s+"), " ")
+}
+
 internal fun File.deleteAllFilesInDirectory() {
     if (!isDirectory) return
 

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/visit/TurboVisitResponse.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/visit/TurboVisitResponse.kt
@@ -1,8 +1,24 @@
 package dev.hotwire.turbo.visit
 
 import com.google.gson.annotations.SerializedName
+import dev.hotwire.turbo.util.truncateMiddle
+import dev.hotwire.turbo.util.withoutNewLineChars
+import dev.hotwire.turbo.util.withoutRepeatingWhitespace
 
 data class TurboVisitResponse(
     @SerializedName("statusCode") val statusCode: Int,
     @SerializedName("responseHTML") val responseHTML: String? = null
-)
+) {
+    override fun toString(): String {
+        val response = responseHTML
+            ?.withoutNewLineChars()
+            ?.withoutRepeatingWhitespace()
+            ?.truncateMiddle(maxChars = 50)
+
+        return "TurboVisitResponse(" +
+                    "statusCode=$statusCode, " +
+                    "responseHTML=$response, " +
+                    "responseLength=${responseHTML?.length ?: 0}" +
+                ")"
+    }
+}

--- a/turbo/src/test/kotlin/dev/hotwire/turbo/visit/TurboVisitResponseTest.kt
+++ b/turbo/src/test/kotlin/dev/hotwire/turbo/visit/TurboVisitResponseTest.kt
@@ -1,0 +1,62 @@
+package dev.hotwire.turbo.visit
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class TurboVisitResponseTest {
+    @Test
+    fun toStringWithNoResponse() {
+        val response = TurboVisitResponse(
+            statusCode = 200,
+            responseHTML = null
+        )
+
+        assertThat(response.toString()).isEqualTo(
+            "TurboVisitResponse(statusCode=200, responseHTML=null, responseLength=0)"
+        )
+    }
+
+    @Test
+    fun toStringWithShortResponse() {
+        val response = TurboVisitResponse(
+            statusCode = 200,
+            responseHTML = "<html><head></head></html>"
+        )
+
+        assertThat(response.toString()).isEqualTo(
+            "TurboVisitResponse(statusCode=200, responseHTML=<html><head></head></html>, responseLength=26)"
+        )
+    }
+
+    @Test
+    fun toStringWithTruncatedResponse() {
+        val response = TurboVisitResponse(
+            statusCode = 200,
+            responseHTML = "<html><head></head>This is a really long response that is truncated.</html>"
+        )
+
+        assertThat(response.toString()).isEqualTo(
+            "TurboVisitResponse(" +
+                "statusCode=200, " +
+                "responseHTML=<html><head></head>This i [...] that is truncated.</html>, " +
+                "responseLength=75" +
+            ")"
+        )
+    }
+
+    @Test
+    fun toStringWithTruncatedResponseAndWhitespace() {
+        val response = TurboVisitResponse(
+            statusCode = 200,
+            responseHTML = "<html>\n<head></head>This   is a really long response that is truncated.\n</html>"
+        )
+
+        assertThat(response.toString()).isEqualTo(
+            "TurboVisitResponse(" +
+                    "statusCode=200, " +
+                    "responseHTML=<html><head></head>This i [...] that is truncated.</html>, " +
+                    "responseLength=79" +
+                    ")"
+        )
+    }
+}


### PR DESCRIPTION
Addresses https://github.com/hotwired/turbo-android/pull/264 by truncating the middle of the html response so it's still clear what type of response was received and adding the response length.

The log output now looks like:
```
TurboVisitResponse(statusCode=200, responseHTML=<!DOCTYPE html><html lang [...] r> </main> </body></html>, responseLength=3036)
```