### PR TITLE
Fix R8 build issues

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.0.0'
+        classpath 'com.android.tools.build:gradle:8.1.0'
         classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.0'
     }
 }

--- a/turbo/build.gradle
+++ b/turbo/build.gradle
@@ -79,8 +79,8 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'org.jetbrains.kotlin:kotlin-reflect:1.8.0'
-    implementation 'com.google.android.material:material:1.8.0'
+    implementation 'org.jetbrains.kotlin:kotlin-reflect:1.9.0'
+    implementation 'com.google.android.material:material:1.9.0'
 
     // AndroidX
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
@@ -91,12 +91,12 @@ dependencies {
     implementation 'com.google.code.gson:gson:2.10.1'
 
     // Networking/API
-    implementation 'com.squareup.okhttp3:okhttp:4.10.0'
-    implementation 'com.squareup.okhttp3:logging-interceptor:4.10.0'
+    implementation 'com.squareup.okhttp3:okhttp:4.11.0'
+    implementation 'com.squareup.okhttp3:logging-interceptor:4.11.0'
 
     // Coroutines
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4'
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3'
 
     // Exported AndroidX dependencies
     api 'androidx.appcompat:appcompat:1.6.1'
@@ -111,12 +111,12 @@ dependencies {
     testImplementation 'androidx.test:core:1.5.0' // Robolectric
     testImplementation 'androidx.navigation:navigation-testing:2.5.3'
     testImplementation 'androidx.arch.core:core-testing:2.2.0'
-    testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.4'
+    testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3'
     testImplementation 'org.assertj:assertj-core:3.24.2'
     testImplementation 'org.robolectric:robolectric:4.9.2'
-    testImplementation 'org.mockito:mockito-core:4.11.0'
+    testImplementation 'org.mockito:mockito-core:5.2.0'
     testImplementation 'com.nhaarman:mockito-kotlin:1.6.0'
-    testImplementation 'com.squareup.okhttp3:mockwebserver:4.10.0'
+    testImplementation 'com.squareup.okhttp3:mockwebserver:4.11.0'
     testImplementation 'junit:junit:4.13.2'
 }
 

--- a/turbo/build.gradle
+++ b/turbo/build.gradle
@@ -52,13 +52,6 @@ android {
     }
 
     buildTypes {
-        create("profiling") {
-            debuggable false
-            minifyEnabled true
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
-            signingConfig getByName("debug").signingConfig
-        }
-
         release {
             minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'

--- a/turbo/build.gradle
+++ b/turbo/build.gradle
@@ -52,6 +52,13 @@ android {
     }
 
     buildTypes {
+        create("profiling") {
+            debuggable false
+            minifyEnabled true
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            signingConfig getByName("debug").signingConfig
+        }
+
         release {
             minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'

--- a/turbo/proguard-consumer-rules.pro
+++ b/turbo/proguard-consumer-rules.pro
@@ -15,3 +15,6 @@
 -keep class sun.misc.Unsafe { *; }
 
 -keep class dev.hotwire.turbo.** { *; }
+
+# Resolve R8 issue: "ERROR: R8: Missing class java.lang.invoke.StringConcatFactory"
+-dontwarn java.lang.invoke.StringConcatFactory

--- a/turbo/proguard-rules.pro
+++ b/turbo/proguard-rules.pro
@@ -24,3 +24,6 @@
 -keep class sun.misc.Unsafe { *; }
 
 -keep class dev.hotwire.turbo.** { *; }
+
+# Resolve R8 issue: "ERROR: R8: Missing class java.lang.invoke.StringConcatFactory"
+-dontwarn java.lang.invoke.StringConcatFactory


### PR DESCRIPTION
This fixes release build issues after upgrading to AGP `8.x`:

```
> Task :turbo:minifyProfilingWithR8 FAILED
ERROR: Missing classes detected while running R8. Please add the missing classes or apply additional keep rules that are generated in /Users/johms/Work/hotwired/turbo-android/turbo/build/outputs/mapping/profiling/missing_rules.txt.
ERROR: R8: Missing class java.lang.invoke.StringConcatFactory (referenced from: java.lang.String dev.hotwire.turbo.config.TurboPathConfiguration$Location.toString() and 27 other contexts)
```