### PR TITLE
Allow animation customization for replace_root presentation (fixes #285)

### DIFF
--- a/turbo/src/main/assets/json/test-configuration.json
+++ b/turbo/src/main/assets/json/test-configuration.json
@@ -25,6 +25,15 @@
     },
     {
       "patterns": [
+        "/toolbar/"
+      ],
+      "properties": {
+        "uri": "turbo://fragment/web/home",
+        "presentation": "replace_root"
+      }
+    },
+    {
+      "patterns": [
         "/feature"
       ],
       "properties": {

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/nav/TurboNavRule.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/nav/TurboNavRule.kt
@@ -81,6 +81,12 @@ internal class TurboNavRule(
         if (newPresentation == TurboNavPresentation.REPLACE_ROOT && newDestination != null) {
             return navOptions {
                 popUpTo(newDestination.id) { inclusive = true }
+                anim {
+                    enter = navOptions.enterAnim
+                    exit = navOptions.exitAnim
+                    popEnter = navOptions.popEnterAnim
+                    popExit = navOptions.popExitAnim
+                }
             }
         }
 

--- a/turbo/src/test/kotlin/dev/hotwire/turbo/nav/TurboNavRuleTest.kt
+++ b/turbo/src/test/kotlin/dev/hotwire/turbo/nav/TurboNavRuleTest.kt
@@ -31,6 +31,7 @@ class TurboNavRuleTest {
     private lateinit var pathConfiguration: TurboPathConfiguration
 
     private val homeUrl = "https://hotwired.dev/home"
+    private val toolbarUrl = "https://hotwired.dev/toolbar/first"
     private val featureUrl = "https://hotwired.dev/feature"
     private val newUrl = "https://hotwired.dev/feature/new"
     private val editUrl = "https://hotwired.dev/feature/edit"
@@ -141,6 +142,32 @@ class TurboNavRuleTest {
         assertThat(rule.newDestinationUri).isEqualTo(webHomeUri)
         assertThat(rule.newDestination).isNotNull()
         assertThat(rule.newNavOptions).isEqualTo(navOptions)
+    }
+
+    @Test
+    fun `replace root when navigating in default context`() {
+        controller.navigate(webHomeDestinationId, locationArgs(homeUrl))
+        val rule = getNavigatorRule(toolbarUrl)
+
+        // Current destination
+        assertThat(rule.previousLocation).isEqualTo(homeUrl)
+        assertThat(rule.currentLocation).isEqualTo(homeUrl)
+        assertThat(rule.currentPresentationContext).isEqualTo(TurboNavPresentationContext.DEFAULT)
+        assertThat(rule.isAtStartDestination).isFalse()
+
+        // New destination
+        assertThat(rule.newLocation).isEqualTo(toolbarUrl)
+        assertThat(rule.newPresentationContext).isEqualTo(TurboNavPresentationContext.DEFAULT)
+        assertThat(rule.newPresentation).isEqualTo(TurboNavPresentation.REPLACE_ROOT)
+        assertThat(rule.newQueryStringPresentation).isEqualTo(TurboNavQueryStringPresentation.DEFAULT)
+        assertThat(rule.newNavigationMode).isEqualTo(TurboNavMode.IN_CONTEXT)
+        assertThat(rule.newModalResult).isNull()
+        assertThat(rule.newDestinationUri).isEqualTo(webHomeUri)
+        assertThat(rule.newDestination).isNotNull()
+        assertThat(rule.newNavOptions.enterAnim).isEqualTo(navOptions.enterAnim)
+        assertThat(rule.newNavOptions.exitAnim).isEqualTo(navOptions.exitAnim)
+        assertThat(rule.newNavOptions.popEnterAnim).isEqualTo(navOptions.popEnterAnim)
+        assertThat(rule.newNavOptions.popExitAnim).isEqualTo(navOptions.popExitAnim)
     }
 
     @Test


### PR DESCRIPTION
Not sure if this is Kotlin-way of doing. Also not sure about tests.