### PR TITLE
Strada sample components in the Demo app

### DIFF
--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -71,6 +71,7 @@ dependencies {
     implementation 'androidx.browser:browser:1.5.0'
     implementation 'org.jetbrains.kotlinx:kotlinx-serialization-json:1.5.0'
     implementation 'com.github.bumptech.glide:glide:4.15.1'
+    implementation 'dev.hotwire:strada:1.0.0-beta2'
 
     implementation project(':turbo')
 }

--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -1,5 +1,17 @@
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
+apply plugin: 'kotlinx-serialization'
+
+buildscript {
+    repositories {
+        google()
+        mavenCentral()
+    }
+
+    dependencies {
+        classpath "org.jetbrains.kotlin:kotlin-serialization:1.8.0"
+    }
+}
 
 android {
     compileSdkVersion 33
@@ -11,6 +23,10 @@ android {
         versionCode 1
         versionName "1.0"
         vectorDrawables.useSupportLibrary = true
+    }
+
+    buildFeatures {
+        viewBinding = true
     }
 
     buildTypes {
@@ -49,10 +65,11 @@ android {
 
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
-    implementation 'com.google.android.material:material:1.8.0'
+    implementation 'com.google.android.material:material:1.9.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
-    implementation 'androidx.recyclerview:recyclerview:1.3.0'
+    implementation 'androidx.recyclerview:recyclerview:1.3.1'
     implementation 'androidx.browser:browser:1.5.0'
+    implementation 'org.jetbrains.kotlinx:kotlinx-serialization-json:1.5.0'
     implementation 'com.github.bumptech.glide:glide:4.15.1'
 
     implementation project(':turbo')

--- a/demo/src/main/assets/json/configuration.json
+++ b/demo/src/main/assets/json/configuration.json
@@ -26,7 +26,8 @@
     },
     {
       "patterns": [
-        "/signin$"
+        "/signin$",
+        "/strada-form$"
       ],
       "properties": {
         "context": "modal",

--- a/demo/src/main/kotlin/dev/hotwire/turbo/demo/base/NavDestination.kt
+++ b/demo/src/main/kotlin/dev/hotwire/turbo/demo/base/NavDestination.kt
@@ -7,6 +7,7 @@ import androidx.browser.customtabs.CustomTabsIntent
 import androidx.browser.customtabs.CustomTabsIntent.SHARE_STATE_ON
 import androidx.navigation.NavOptions
 import androidx.navigation.navOptions
+import dev.hotwire.strada.BridgeDestination
 import dev.hotwire.turbo.config.TurboPathConfigurationProperties
 import dev.hotwire.turbo.config.context
 import dev.hotwire.turbo.demo.R
@@ -14,7 +15,7 @@ import dev.hotwire.turbo.demo.util.BASE_URL
 import dev.hotwire.turbo.nav.TurboNavDestination
 import dev.hotwire.turbo.nav.TurboNavPresentationContext.MODAL
 
-interface NavDestination : TurboNavDestination {
+interface NavDestination : TurboNavDestination, BridgeDestination {
     val menuProgress: MenuItem?
         get() = toolbarForNavigation()?.menu?.findItem(R.id.menu_progress)
 
@@ -36,6 +37,10 @@ interface NavDestination : TurboNavDestination {
             MODAL -> slideAnimation()
             else -> super.getNavigationOptions(newLocation, newPathProperties)
         }
+    }
+
+    override fun bridgeWebViewIsReady(): Boolean {
+        return session.isReady
     }
 
     private fun isNavigable(location: String): Boolean {

--- a/demo/src/main/kotlin/dev/hotwire/turbo/demo/features/web/WebFragment.kt
+++ b/demo/src/main/kotlin/dev/hotwire/turbo/demo/features/web/WebFragment.kt
@@ -2,19 +2,52 @@ package dev.hotwire.turbo.demo.features.web
 
 import android.os.Bundle
 import android.view.View
+import dev.hotwire.strada.BridgeDelegate
 import dev.hotwire.turbo.demo.R
 import dev.hotwire.turbo.demo.base.NavDestination
+import dev.hotwire.turbo.demo.strada.bridgeComponentFactories
 import dev.hotwire.turbo.demo.util.SIGN_IN_URL
 import dev.hotwire.turbo.fragments.TurboWebFragment
 import dev.hotwire.turbo.nav.TurboNavGraphDestination
+import dev.hotwire.turbo.views.TurboWebView
 import dev.hotwire.turbo.visit.TurboVisitAction.REPLACE
 import dev.hotwire.turbo.visit.TurboVisitOptions
 
 @TurboNavGraphDestination(uri = "turbo://fragment/web")
 open class WebFragment : TurboWebFragment(), NavDestination {
+    private val bridgeDelegate by lazy {
+        BridgeDelegate(
+            location = location,
+            destination = this,
+            componentFactories =  bridgeComponentFactories
+        )
+    }
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         setupMenu()
+        viewLifecycleOwner.lifecycle.addObserver(bridgeDelegate)
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        viewLifecycleOwner.lifecycle.removeObserver(bridgeDelegate)
+    }
+
+    override fun onColdBootPageStarted(location: String) {
+        bridgeDelegate.onColdBootPageStarted()
+    }
+
+    override fun onColdBootPageCompleted(location: String) {
+        bridgeDelegate.onColdBootPageCompleted()
+    }
+
+    override fun onWebViewAttached(webView: TurboWebView) {
+        bridgeDelegate.onWebViewAttached(webView)
+    }
+
+    override fun onWebViewDetached(webView: TurboWebView) {
+        bridgeDelegate.onWebViewDetached()
     }
 
     override fun onFormSubmissionStarted(location: String) {

--- a/demo/src/main/kotlin/dev/hotwire/turbo/demo/main/MainActivity.kt
+++ b/demo/src/main/kotlin/dev/hotwire/turbo/demo/main/MainActivity.kt
@@ -3,6 +3,7 @@ package dev.hotwire.turbo.demo.main
 import android.os.Bundle
 import android.webkit.WebView
 import androidx.appcompat.app.AppCompatActivity
+import dev.hotwire.strada.KotlinXJsonConverter
 import dev.hotwire.strada.Strada
 import dev.hotwire.turbo.BuildConfig
 import dev.hotwire.turbo.activities.TurboActivity
@@ -22,6 +23,8 @@ class MainActivity : AppCompatActivity(), TurboActivity {
     }
 
     private fun configApp() {
+        Strada.config.jsonConverter = KotlinXJsonConverter()
+
         if (BuildConfig.DEBUG) {
             Turbo.config.debugLoggingEnabled = true
             Strada.config.debugLoggingEnabled = true

--- a/demo/src/main/kotlin/dev/hotwire/turbo/demo/main/MainActivity.kt
+++ b/demo/src/main/kotlin/dev/hotwire/turbo/demo/main/MainActivity.kt
@@ -3,6 +3,7 @@ package dev.hotwire.turbo.demo.main
 import android.os.Bundle
 import android.webkit.WebView
 import androidx.appcompat.app.AppCompatActivity
+import dev.hotwire.strada.Strada
 import dev.hotwire.turbo.BuildConfig
 import dev.hotwire.turbo.activities.TurboActivity
 import dev.hotwire.turbo.config.Turbo
@@ -23,6 +24,7 @@ class MainActivity : AppCompatActivity(), TurboActivity {
     private fun configApp() {
         if (BuildConfig.DEBUG) {
             Turbo.config.debugLoggingEnabled = true
+            Strada.config.debugLoggingEnabled = true
             WebView.setWebContentsDebuggingEnabled(true)
         }
     }

--- a/demo/src/main/kotlin/dev/hotwire/turbo/demo/main/MainSessionNavHostFragment.kt
+++ b/demo/src/main/kotlin/dev/hotwire/turbo/demo/main/MainSessionNavHostFragment.kt
@@ -49,7 +49,7 @@ class MainSessionNavHostFragment : TurboSessionNavHostFragment() {
         session.webView.settings.userAgentString = session.webView.customUserAgent
         session.webView.initDayNightTheme()
 
-        // Initialize Strada bridge
+        // Initialize Strada bridge with new WebView instance
         Bridge.initialize(session.webView)
     }
 }

--- a/demo/src/main/kotlin/dev/hotwire/turbo/demo/main/MainSessionNavHostFragment.kt
+++ b/demo/src/main/kotlin/dev/hotwire/turbo/demo/main/MainSessionNavHostFragment.kt
@@ -2,6 +2,7 @@ package dev.hotwire.turbo.demo.main
 
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
+import dev.hotwire.strada.Bridge
 import dev.hotwire.turbo.config.TurboPathConfiguration
 import dev.hotwire.turbo.demo.features.imageviewer.ImageViewerFragment
 import dev.hotwire.turbo.demo.features.numbers.NumberBottomSheetFragment
@@ -43,7 +44,12 @@ class MainSessionNavHostFragment : TurboSessionNavHostFragment() {
 
     override fun onSessionCreated() {
         super.onSessionCreated()
+
+        // Configure WebView
         session.webView.settings.userAgentString = session.webView.customUserAgent
         session.webView.initDayNightTheme()
+
+        // Initialize Strada bridge
+        Bridge.initialize(session.webView)
     }
 }

--- a/demo/src/main/kotlin/dev/hotwire/turbo/demo/strada/BridgeComponentFactories.kt
+++ b/demo/src/main/kotlin/dev/hotwire/turbo/demo/strada/BridgeComponentFactories.kt
@@ -4,5 +4,6 @@ import dev.hotwire.strada.BridgeComponentFactory
 
 val bridgeComponentFactories = listOf(
     BridgeComponentFactory("form", ::FormComponent),
-    BridgeComponentFactory("menu", ::MenuComponent)
+    BridgeComponentFactory("menu", ::MenuComponent),
+    BridgeComponentFactory("overflow-menu", ::OverflowMenuComponent)
 )

--- a/demo/src/main/kotlin/dev/hotwire/turbo/demo/strada/BridgeComponentFactories.kt
+++ b/demo/src/main/kotlin/dev/hotwire/turbo/demo/strada/BridgeComponentFactories.kt
@@ -3,5 +3,6 @@ package dev.hotwire.turbo.demo.strada
 import dev.hotwire.strada.BridgeComponentFactory
 
 val bridgeComponentFactories = listOf(
-    BridgeComponentFactory("form", ::FormComponent)
+    BridgeComponentFactory("form", ::FormComponent),
+    BridgeComponentFactory("menu", ::MenuComponent)
 )

--- a/demo/src/main/kotlin/dev/hotwire/turbo/demo/strada/BridgeComponentFactories.kt
+++ b/demo/src/main/kotlin/dev/hotwire/turbo/demo/strada/BridgeComponentFactories.kt
@@ -1,0 +1,7 @@
+package dev.hotwire.turbo.demo.strada
+
+import dev.hotwire.strada.BridgeComponentFactory
+
+val bridgeComponentFactories = listOf(
+    BridgeComponentFactory("form", ::FormComponent)
+)

--- a/demo/src/main/kotlin/dev/hotwire/turbo/demo/strada/FormComponent.kt
+++ b/demo/src/main/kotlin/dev/hotwire/turbo/demo/strada/FormComponent.kt
@@ -1,0 +1,17 @@
+package dev.hotwire.turbo.demo.strada
+
+import android.util.Log
+import dev.hotwire.strada.BridgeComponent
+import dev.hotwire.strada.BridgeDelegate
+import dev.hotwire.strada.Message
+import dev.hotwire.turbo.demo.base.NavDestination
+
+class FormComponent(
+    name: String,
+    delegate: BridgeDelegate<NavDestination>
+) : BridgeComponent<NavDestination>(name, delegate) {
+
+    override fun onReceive(message: Message) {
+        Log.d("Demo", "FormComponent message received: $message")
+    }
+}

--- a/demo/src/main/kotlin/dev/hotwire/turbo/demo/strada/FormComponent.kt
+++ b/demo/src/main/kotlin/dev/hotwire/turbo/demo/strada/FormComponent.kt
@@ -15,6 +15,10 @@ import dev.hotwire.turbo.demo.databinding.FormComponentSubmitBinding
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
+/**
+ * Bridge component to display a submit button in the native toolbar,
+ * which will submit the form on the page when tapped.
+ */
 class FormComponent(
     name: String,
     private val delegate: BridgeDelegate<NavDestination>

--- a/demo/src/main/kotlin/dev/hotwire/turbo/demo/strada/FormComponent.kt
+++ b/demo/src/main/kotlin/dev/hotwire/turbo/demo/strada/FormComponent.kt
@@ -1,17 +1,88 @@
 package dev.hotwire.turbo.demo.strada
 
 import android.util.Log
+import android.view.LayoutInflater
+import android.view.Menu
+import android.view.MenuItem
+import androidx.appcompat.widget.Toolbar
+import androidx.fragment.app.Fragment
 import dev.hotwire.strada.BridgeComponent
 import dev.hotwire.strada.BridgeDelegate
 import dev.hotwire.strada.Message
+import dev.hotwire.turbo.demo.R
 import dev.hotwire.turbo.demo.base.NavDestination
+import dev.hotwire.turbo.demo.databinding.FormComponentSubmitBinding
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 
 class FormComponent(
     name: String,
-    delegate: BridgeDelegate<NavDestination>
+    private val delegate: BridgeDelegate<NavDestination>
 ) : BridgeComponent<NavDestination>(name, delegate) {
 
+    private val submitButtonItemId = 37
+    private var submitMenuItem: MenuItem? = null
+    private val fragment: Fragment
+        get() = delegate.destination.fragment
+    private val toolbar: Toolbar?
+        get() = fragment.view?.findViewById(R.id.toolbar)
+
     override fun onReceive(message: Message) {
-        Log.d("Demo", "FormComponent message received: $message")
+        when (message.event) {
+            "connect" -> handleConnectEvent(message)
+            "submitEnabled" -> handleSubmitEnabled()
+            "submitDisabled" -> handleSubmitDisabled()
+            else -> Log.w("TurboDemo", "Unknown event for message: $message")
+        }
     }
+
+    private fun handleConnectEvent(message: Message) {
+        val data = message.data<MessageData>() ?: return
+        showToolbarButton(data)
+    }
+
+    private fun handleSubmitEnabled() {
+        toggleSubmitButton(true)
+    }
+
+    private fun handleSubmitDisabled() {
+        toggleSubmitButton(false)
+    }
+
+    private fun showToolbarButton(data: MessageData) {
+        val menu = toolbar?.menu ?: return
+        val inflater = LayoutInflater.from(fragment.requireContext())
+        val binding = FormComponentSubmitBinding.inflate(inflater)
+        val order = 999 // Show as the right-most button
+
+        binding.formSubmit.apply {
+            text = data.title
+            setOnClickListener {
+                performSubmit()
+            }
+        }
+
+        menu.removeItem(submitButtonItemId)
+        submitMenuItem = menu.add(Menu.NONE, submitButtonItemId, order, data.title).apply {
+            actionView = binding.root
+            setShowAsAction(MenuItem.SHOW_AS_ACTION_ALWAYS)
+        }
+    }
+
+    private fun toggleSubmitButton(enable: Boolean) {
+        val layout = submitMenuItem?.actionView ?: return
+
+        FormComponentSubmitBinding.bind(layout).apply {
+            formSubmit.isEnabled = enable
+        }
+    }
+
+    private fun performSubmit(): Boolean {
+        return replyTo("connect")
+    }
+
+    @Serializable
+    data class MessageData(
+        @SerialName("submitTitle") val title: String
+    )
 }

--- a/demo/src/main/kotlin/dev/hotwire/turbo/demo/strada/MenuComponent.kt
+++ b/demo/src/main/kotlin/dev/hotwire/turbo/demo/strada/MenuComponent.kt
@@ -2,14 +2,12 @@ package dev.hotwire.turbo.demo.strada
 
 import android.util.Log
 import android.view.LayoutInflater
-import androidx.appcompat.widget.Toolbar
 import androidx.fragment.app.Fragment
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import dev.hotwire.strada.BridgeComponent
 import dev.hotwire.strada.BridgeDelegate
 import dev.hotwire.strada.Message
-import dev.hotwire.turbo.demo.R
 import dev.hotwire.turbo.demo.base.NavDestination
 import dev.hotwire.turbo.demo.databinding.MenuComponentBottomSheetBinding
 import kotlinx.serialization.SerialName

--- a/demo/src/main/kotlin/dev/hotwire/turbo/demo/strada/MenuComponent.kt
+++ b/demo/src/main/kotlin/dev/hotwire/turbo/demo/strada/MenuComponent.kt
@@ -1,0 +1,84 @@
+package dev.hotwire.turbo.demo.strada
+
+import android.util.Log
+import android.view.LayoutInflater
+import androidx.appcompat.widget.Toolbar
+import androidx.fragment.app.Fragment
+import androidx.recyclerview.widget.LinearLayoutManager
+import com.google.android.material.bottomsheet.BottomSheetDialog
+import dev.hotwire.strada.BridgeComponent
+import dev.hotwire.strada.BridgeDelegate
+import dev.hotwire.strada.Message
+import dev.hotwire.turbo.demo.R
+import dev.hotwire.turbo.demo.base.NavDestination
+import dev.hotwire.turbo.demo.databinding.MenuComponentBottomSheetBinding
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Bridge component to display a native bottom sheet menu, which will
+ * send the selected index of the tapped menu item back to the web.
+ */
+class MenuComponent(
+    name: String,
+    private val delegate: BridgeDelegate<NavDestination>
+) : BridgeComponent<NavDestination>(name, delegate) {
+
+    private val fragment: Fragment
+        get() = delegate.destination.fragment
+
+    override fun onReceive(message: Message) {
+        when (message.event) {
+            "display" -> handleDisplayEvent(message)
+            else -> Log.w("TurboDemo", "Unknown event for message: $message")
+        }
+    }
+
+    private fun handleDisplayEvent(message: Message) {
+        val data = message.data<MessageData>() ?: return
+        showBottomSheet(data.title, data.items)
+    }
+
+    private fun showBottomSheet(title: String, items: List<Item>) {
+        val view = fragment.view?.rootView ?: return
+        val inflater = LayoutInflater.from(view.context)
+        val bottomSheet = BottomSheetDialog(view.context)
+        val binding = MenuComponentBottomSheetBinding.inflate(inflater)
+
+        binding.toolbar.title = title
+        binding.recyclerView.layoutManager = LinearLayoutManager(view.context)
+        binding.recyclerView.adapter = MenuComponentAdapter().apply {
+            setData(items)
+            setListener {
+                bottomSheet.dismiss()
+                onItemSelected(it)
+            }
+        }
+
+        bottomSheet.apply {
+            setContentView(binding.root)
+            show()
+        }
+    }
+
+    private fun onItemSelected(item: Item) {
+        replyTo("display", SelectionMessageData(item.index))
+    }
+
+    @Serializable
+    data class MessageData(
+        @SerialName("title") val title: String,
+        @SerialName("items") val items: List<Item>
+    )
+
+    @Serializable
+    data class Item(
+        @SerialName("title") val title: String,
+        @SerialName("index") val index: Int
+    )
+
+    @Serializable
+    data class SelectionMessageData(
+        @SerialName("selectedIndex") val selectedIndex: Int
+    )
+}

--- a/demo/src/main/kotlin/dev/hotwire/turbo/demo/strada/MenuComponentAdapter.kt
+++ b/demo/src/main/kotlin/dev/hotwire/turbo/demo/strada/MenuComponentAdapter.kt
@@ -1,4 +1,4 @@
-package dev.hotwire.turbo.demo.features.numbers
+package dev.hotwire.turbo.demo.strada
 
 import android.annotation.SuppressLint
 import android.view.LayoutInflater
@@ -8,18 +8,23 @@ import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.textview.MaterialTextView
 import dev.hotwire.turbo.demo.R
 
-class NumbersAdapter(val callback: NumbersFragmentCallback) : RecyclerView.Adapter<NumbersAdapter.ViewHolder>() {
-    private val type = R.layout.adapter_numbers_row
+class MenuComponentAdapter : RecyclerView.Adapter<MenuComponentAdapter.ViewHolder>() {
+    private val type = R.layout.menu_component_adapter_row
+    private var action: ((MenuComponent.Item) -> Unit)? = null
 
-    private var items = emptyList<Int>()
+    private var items = emptyList<MenuComponent.Item>()
         @SuppressLint("NotifyDataSetChanged")
         set(value) {
             field = value
             notifyDataSetChanged()
         }
 
-    fun setData(numbers: List<Int>) {
-        items = numbers
+    fun setData(items: List<MenuComponent.Item>) {
+        this.items = items
+    }
+
+    fun setListener(action: (item: MenuComponent.Item) -> Unit) {
+        this.action = action
     }
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
@@ -40,12 +45,12 @@ class NumbersAdapter(val callback: NumbersFragmentCallback) : RecyclerView.Adapt
     }
 
     inner class ViewHolder(view: View) : RecyclerView.ViewHolder(view) {
-        private val textView: MaterialTextView = view.findViewById(R.id.number)
+        private val textView: MaterialTextView = view.findViewById(R.id.title)
 
-        fun bind(number: Int) {
-            textView.text = "$number"
+        fun bind(item: MenuComponent.Item) {
+            textView.text = item.title
             itemView.setOnClickListener {
-                callback.onItemClicked(number)
+                action?.invoke(item)
             }
         }
     }

--- a/demo/src/main/kotlin/dev/hotwire/turbo/demo/strada/OverflowMenuComponent.kt
+++ b/demo/src/main/kotlin/dev/hotwire/turbo/demo/strada/OverflowMenuComponent.kt
@@ -1,0 +1,67 @@
+package dev.hotwire.turbo.demo.strada
+
+import android.util.Log
+import androidx.appcompat.widget.Toolbar
+import androidx.fragment.app.Fragment
+import dev.hotwire.strada.BridgeComponent
+import dev.hotwire.strada.BridgeDelegate
+import dev.hotwire.strada.Message
+import dev.hotwire.turbo.demo.R
+import dev.hotwire.turbo.demo.base.NavDestination
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Bridge component to display a native 3-dot menu in the toolbar, which
+ * will will notify the web when it has been tapped.
+ */
+class OverflowMenuComponent(
+    name: String,
+    private val delegate: BridgeDelegate<NavDestination>
+) : BridgeComponent<NavDestination>(name, delegate) {
+
+    private val fragment: Fragment
+        get() = delegate.destination.fragment
+    private val toolbar: Toolbar?
+        get() = fragment.view?.findViewById(R.id.toolbar)
+
+    override fun onReceive(message: Message) {
+        when (message.event) {
+            "connect" -> handleConnectEvent(message)
+            else -> Log.w("TurboDemo", "Unknown event for message: $message")
+        }
+    }
+
+    private fun handleConnectEvent(message: Message) {
+        val data = message.data<MessageData>() ?: return
+        showOverflowMenuItem(data)
+    }
+
+    private fun showOverflowMenuItem(data: MessageData) {
+        val toolbar = toolbar ?: return
+
+        toolbar.menu.findItem(R.id.overflow)?.apply {
+            isVisible = true
+            title = data.label
+        }
+
+        toolbar.setOnMenuItemClickListener {
+            when (it.itemId) {
+                R.id.overflow -> {
+                    performClick()
+                    true
+                }
+                else -> false
+            }
+        }
+    }
+
+    private fun performClick() {
+        replyTo("connect")
+    }
+
+    @Serializable
+    data class MessageData(
+        @SerialName("label") val label: String
+    )
+}

--- a/demo/src/main/kotlin/dev/hotwire/turbo/demo/util/Extensions.kt
+++ b/demo/src/main/kotlin/dev/hotwire/turbo/demo/util/Extensions.kt
@@ -8,9 +8,11 @@ import androidx.appcompat.widget.Toolbar
 import androidx.core.content.ContextCompat
 import androidx.webkit.WebSettingsCompat
 import androidx.webkit.WebViewFeature
+import dev.hotwire.strada.Strada
 import dev.hotwire.turbo.config.Turbo
 import dev.hotwire.turbo.config.TurboPathConfigurationProperties
 import dev.hotwire.turbo.demo.R
+import dev.hotwire.turbo.demo.strada.bridgeComponentFactories
 
 val TurboPathConfigurationProperties.description: String?
     get() = get("description")
@@ -38,7 +40,8 @@ fun WebView.initDayNightTheme() {
 val WebView.customUserAgent: String
     get() {
         val turboSubstring = Turbo.userAgentSubstring()
-        return "$turboSubstring; ${settings.userAgentString}"
+        val stradaSubstring = Strada.userAgentSubstring(bridgeComponentFactories)
+        return "$turboSubstring; $stradaSubstring; ${settings.userAgentString}"
     }
 
 private fun isNightModeEnabled(context: Context): Boolean {

--- a/demo/src/main/res/drawable/ic_overflow.xml
+++ b/demo/src/main/res/drawable/ic_overflow.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M12,8c1.1,0 2,-0.9 2,-2s-0.9,-2 -2,-2 -2,0.9 -2,2 0.9,2 2,2zM12,10c-1.1,0 -2,0.9 -2,2s0.9,2 2,2 2,-0.9 2,-2 -0.9,-2 -2,-2zM12,16c-1.1,0 -2,0.9 -2,2s0.9,2 2,2 2,-0.9 2,-2 -0.9,-2 -2,-2z"/>
+</vector>

--- a/demo/src/main/res/layout/form_component_submit.xml
+++ b/demo/src/main/res/layout/form_component_submit.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="wrap_content"
+    android:layout_height="match_parent"
+    android:layout_gravity="end|center_vertical"
+    android:paddingEnd="16dp">
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/form_submit"
+        android:layout_width="wrap_content"
+        android:layout_height="48dp"
+        android:textColor="@color/black" />
+
+</FrameLayout>

--- a/demo/src/main/res/layout/menu_component_adapter_row.xml
+++ b/demo/src/main/res/layout/menu_component_adapter_row.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="?selectableItemBackground">
+
+    <com.google.android.material.textview.MaterialTextView
+        style="@style/TextAppearance.AppCompat.Menu"
+        android:id="@+id/title"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:minHeight="48dp"
+        android:paddingLeft="16dp"
+        android:paddingTop="8dp"
+        android:paddingRight="16dp"
+        android:paddingBottom="8dp"
+        android:textSize="18sp"
+        app:layout_constraintTop_toTopOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/demo/src/main/res/layout/menu_component_bottom_sheet.xml
+++ b/demo/src/main/res/layout/menu_component_bottom_sheet.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/transparent">
+
+    <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/app_bar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@color/transparent"
+        android:stateListAnimator="@null"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/recycler_view"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/app_bar" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/demo/src/main/res/menu/web.xml
+++ b/demo/src/main/res/menu/web.xml
@@ -11,4 +11,13 @@
         app:showAsAction="always"
         tools:ignore="AlwaysShowAction" />
 
+    <item
+        android:id="@+id/overflow"
+        android:icon="@drawable/ic_overflow"
+        android:orderInCategory="999"
+        android:visible="false"
+        app:iconTint="?colorControlNormal"
+        app:showAsAction="always"
+        tools:ignore="AlwaysShowAction" />
+
 </menu>


### PR DESCRIPTION
This add 3 Strada sample components to the Demo app:
- `FormComponent`: displays a submit button in the native toolbar, which will submit the form on the page when tapped.
- `MenuComponent`: displays a native bottom sheet menu, which will send the selected index of the tapped menu item back to the web.
- `OverflowMenuComponent`: displays a native 3-dot menu in the toolbar, which will will notify the web when it has been tapped.