### PR TITLE
Perform same-page visit proposals without recreating the current destination

### DIFF
--- a/turbo/src/main/assets/js/turbo_bridge.js
+++ b/turbo/src/main/assets/js/turbo_bridge.js
@@ -104,7 +104,7 @@
           Turbo.navigator.view.scrollToAnchorFromLocation(location)
         } else if (window.Turbo && Turbo.navigator.location?.href === location.href) {
           // Refresh the page without native proposal
-          TurboSession.visitProposalIsPageRefresh(location.toString(), JSON.stringify(options))
+          TurboSession.visitProposalRefreshingPage(location.toString(), JSON.stringify(options))
           this.visitLocationWithOptionsAndRestorationIdentifier(location, JSON.stringify(options), Turbo.navigator.restorationIdentifier)
         } else {
           // Propose the visit

--- a/turbo/src/main/assets/js/turbo_bridge.js
+++ b/turbo/src/main/assets/js/turbo_bridge.js
@@ -103,7 +103,7 @@
           TurboSession.visitProposalScrollingToAnchor(location.toString(), JSON.stringify(options))
           Turbo.navigator.view.scrollToAnchorFromLocation(location)
         } else {
-          // Propose the visit to the app
+          // Propose the visit
           TurboSession.visitProposedToLocation(location.toString(), JSON.stringify(options))
         }
     }

--- a/turbo/src/main/assets/js/turbo_bridge.js
+++ b/turbo/src/main/assets/js/turbo_bridge.js
@@ -102,6 +102,9 @@
           // Scroll to the anchor on the page
           TurboSession.visitProposalScrollingToAnchor(location.toString(), JSON.stringify(options))
           Turbo.navigator.view.scrollToAnchorFromLocation(location)
+        } else if (Turbo.navigator.location.href === location.href) {
+          TurboSession.visitProposalIsPageRefresh(location.toString(), JSON.stringify(options))
+          this.visitLocationWithOptionsAndRestorationIdentifier(location, JSON.stringify(options), Turbo.navigator.restorationIdentifier)
         } else {
           // Propose the visit
           TurboSession.visitProposedToLocation(location.toString(), JSON.stringify(options))

--- a/turbo/src/main/assets/js/turbo_bridge.js
+++ b/turbo/src/main/assets/js/turbo_bridge.js
@@ -102,7 +102,8 @@
           // Scroll to the anchor on the page
           TurboSession.visitProposalScrollingToAnchor(location.toString(), JSON.stringify(options))
           Turbo.navigator.view.scrollToAnchorFromLocation(location)
-        } else if (Turbo.navigator.location.href === location.href) {
+        } else if (window.Turbo && Turbo.navigator.location.href === location.href) {
+          // Refresh the page without native proposal
           TurboSession.visitProposalIsPageRefresh(location.toString(), JSON.stringify(options))
           this.visitLocationWithOptionsAndRestorationIdentifier(location, JSON.stringify(options), Turbo.navigator.restorationIdentifier)
         } else {

--- a/turbo/src/main/assets/js/turbo_bridge.js
+++ b/turbo/src/main/assets/js/turbo_bridge.js
@@ -118,7 +118,7 @@
     }
 
     visitStarted(visit) {
-      TurboSession.visitStarted(visit.identifier, visit.hasCachedSnapshot(), visit.location.toString())
+      TurboSession.visitStarted(visit.identifier, visit.hasCachedSnapshot(), visit.isPageRefresh || false, visit.location.toString())
       this.currentVisit = visit
       this.issueRequestForVisitWithIdentifier(visit.identifier)
       this.changeHistoryForVisitWithIdentifier(visit.identifier)

--- a/turbo/src/main/assets/js/turbo_bridge.js
+++ b/turbo/src/main/assets/js/turbo_bridge.js
@@ -98,14 +98,14 @@
     // Adapter interface
 
     visitProposedToLocation(location, options) {
-      if (window.Turbo && typeof Turbo.navigator.locationWithActionIsSamePage === "function") {
-        if (Turbo.navigator.locationWithActionIsSamePage(location, options.action)) {
+        if (window.Turbo && Turbo.navigator.locationWithActionIsSamePage(location, options.action)) {
+          // Scroll to the anchor on the page
+          TurboSession.visitProposalScrollingToAnchor(location.toString(), JSON.stringify(options))
           Turbo.navigator.view.scrollToAnchorFromLocation(location)
-          return
+        } else {
+          // Propose the visit to the app
+          TurboSession.visitProposedToLocation(location.toString(), JSON.stringify(options))
         }
-      }
-
-      TurboSession.visitProposedToLocation(location.toString(), JSON.stringify(options))
     }
 
     // Turbolinks 5

--- a/turbo/src/main/assets/js/turbo_bridge.js
+++ b/turbo/src/main/assets/js/turbo_bridge.js
@@ -102,7 +102,7 @@
           // Scroll to the anchor on the page
           TurboSession.visitProposalScrollingToAnchor(location.toString(), JSON.stringify(options))
           Turbo.navigator.view.scrollToAnchorFromLocation(location)
-        } else if (window.Turbo && Turbo.navigator.location.href === location.href) {
+        } else if (window.Turbo && Turbo.navigator.location?.href === location.href) {
           // Refresh the page without native proposal
           TurboSession.visitProposalIsPageRefresh(location.toString(), JSON.stringify(options))
           this.visitLocationWithOptionsAndRestorationIdentifier(location, JSON.stringify(options), Turbo.navigator.restorationIdentifier)

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/session/TurboSession.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/session/TurboSession.kt
@@ -238,11 +238,14 @@ class TurboSession internal constructor(
      * @param location The location being visited.
      */
     @JavascriptInterface
-    fun visitStarted(visitIdentifier: String, visitHasCachedSnapshot: Boolean, location: String) {
+    fun visitStarted(visitIdentifier: String, visitHasCachedSnapshot: Boolean,
+                     visitIsPageRefresh: Boolean, location: String
+    ) {
         logEvent(
             "visitStarted", "location" to location,
             "visitIdentifier" to visitIdentifier,
-            "visitHasCachedSnapshot" to visitHasCachedSnapshot
+            "visitHasCachedSnapshot" to visitHasCachedSnapshot,
+            "visitIsPageRefresh" to visitIsPageRefresh
         )
 
         currentVisit?.identifier = visitIdentifier

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/session/TurboSession.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/session/TurboSession.kt
@@ -179,7 +179,7 @@ class TurboSession internal constructor(
     // Callbacks from Turbo JS Core
 
     /**
-     * Called by Turbo bridge when a new visit is initiated.
+     * Called by Turbo bridge when a new visit is proposed.
      *
      * Warning: This method is public so it can be used as a Javascript Interface.
      * You should never call this directly as it could lead to unintended behavior.
@@ -191,8 +191,36 @@ class TurboSession internal constructor(
     fun visitProposedToLocation(location: String, optionsJson: String) {
         val options = TurboVisitOptions.fromJSON(optionsJson) ?: return
 
-        logEvent("visitProposedToLocation", "location" to location, "options" to options)
-        callback { it.visitProposedToLocation(location, options) }
+        val visit = currentVisit?.copy(
+            restoreWithCachedSnapshot = false,
+            options = options
+        )
+
+        if (visit?.location == location) {
+            // Automatically re-visit the same page location
+            logEvent("visitProposedToSamePage", "location" to location, "options" to options)
+            visitLocation(visit)
+        } else {
+            // Propose the visit to the app to decide how to handle it
+            logEvent("visitProposedToLocation", "location" to location, "options" to options)
+            callback { it.visitProposedToLocation(location, options) }
+        }
+    }
+
+    /**
+     * Called by Turbo bridge when a new visit proposal will scroll to an anchor
+     * on the same page.
+     *
+     * Warning: This method is public so it can be used as a Javascript Interface.
+     * You should never call this directly as it could lead to unintended behavior.
+     *
+     * @param location The location to visit.
+     * @param optionsJson A JSON block to be serialized into [TurboVisitOptions].
+     */
+    @JavascriptInterface
+    fun visitProposalScrollingToAnchor(location: String, optionsJson: String) {
+        val options = TurboVisitOptions.fromJSON(optionsJson) ?: return
+        logEvent("visitProposalScrollingToAnchor", "location" to location, "options" to options)
     }
 
     /**

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/session/TurboSession.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/session/TurboSession.kt
@@ -206,9 +206,9 @@ class TurboSession internal constructor(
      * @param optionsJson A JSON block to be serialized into [TurboVisitOptions].
      */
     @JavascriptInterface
-    fun visitProposalIsPageRefresh(location: String, optionsJson: String) {
+    fun visitProposalRefreshingPage(location: String, optionsJson: String) {
         val options = TurboVisitOptions.fromJSON(optionsJson) ?: return
-        logEvent("visitProposalIsPageRefresh", "location" to location, "options" to options)
+        logEvent("visitProposalRefreshingPage", "location" to location, "options" to options)
     }
 
     /**

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/session/TurboSession.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/session/TurboSession.kt
@@ -191,20 +191,24 @@ class TurboSession internal constructor(
     fun visitProposedToLocation(location: String, optionsJson: String) {
         val options = TurboVisitOptions.fromJSON(optionsJson) ?: return
 
-        val visit = currentVisit?.copy(
-            restoreWithCachedSnapshot = false,
-            options = options
-        )
+        logEvent("visitProposedToLocation", "location" to location, "options" to options)
+        callback { it.visitProposedToLocation(location, options) }
+    }
 
-        if (visit?.location == location) {
-            // Automatically re-visit the same page location
-            logEvent("visitProposedToSamePage", "location" to location, "options" to options)
-            visitLocation(visit)
-        } else {
-            // Propose the visit to the app to decide how to handle it
-            logEvent("visitProposedToLocation", "location" to location, "options" to options)
-            callback { it.visitProposedToLocation(location, options) }
-        }
+    /**
+     * Called by Turbo bridge when a new visit proposal will refresh the
+     * current page.
+     *
+     * Warning: This method is public so it can be used as a Javascript Interface.
+     * You should never call this directly as it could lead to unintended behavior.
+     *
+     * @param location The location to visit.
+     * @param optionsJson A JSON block to be serialized into [TurboVisitOptions].
+     */
+    @JavascriptInterface
+    fun visitProposalIsPageRefresh(location: String, optionsJson: String) {
+        val options = TurboVisitOptions.fromJSON(optionsJson) ?: return
+        logEvent("visitProposalIsPageRefresh", "location" to location, "options" to options)
     }
 
     /**

--- a/turbo/src/test/kotlin/dev/hotwire/turbo/session/TurboSessionTest.kt
+++ b/turbo/src/test/kotlin/dev/hotwire/turbo/session/TurboSessionTest.kt
@@ -65,11 +65,23 @@ class TurboSessionTest {
     @Test
     fun visitProposedToLocationFiresCallback() {
         val options = TurboVisitOptions()
+        val newLocation = "${visit.location}/page"
+
+        session.currentVisit = visit
+        session.visitProposedToLocation(newLocation, options.toJson())
+
+        verify(callback).visitProposedToLocation(newLocation, options)
+    }
+
+    @Test
+    fun visitProposedToSameLocationStartsVisit() {
+        val options = TurboVisitOptions()
 
         session.currentVisit = visit
         session.visitProposedToLocation(visit.location, options.toJson())
 
-        verify(callback).visitProposedToLocation(visit.location, options)
+        verify(callback, never()).visitProposedToLocation(visit.location, options)
+        verify(webView).visitLocation(visit.location, options, "")
     }
 
     @Test

--- a/turbo/src/test/kotlin/dev/hotwire/turbo/session/TurboSessionTest.kt
+++ b/turbo/src/test/kotlin/dev/hotwire/turbo/session/TurboSessionTest.kt
@@ -74,17 +74,6 @@ class TurboSessionTest {
     }
 
     @Test
-    fun visitProposedToSameLocationStartsVisit() {
-        val options = TurboVisitOptions()
-
-        session.currentVisit = visit
-        session.visitProposedToLocation(visit.location, options.toJson())
-
-        verify(callback, never()).visitProposedToLocation(visit.location, options)
-        verify(webView).visitLocation(visit.location, options, "")
-    }
-
-    @Test
     fun visitStartedSavesCurrentVisitIdentifier() {
         val visitIdentifier = "12345"
 

--- a/turbo/src/test/kotlin/dev/hotwire/turbo/session/TurboSessionTest.kt
+++ b/turbo/src/test/kotlin/dev/hotwire/turbo/session/TurboSessionTest.kt
@@ -78,7 +78,12 @@ class TurboSessionTest {
         val visitIdentifier = "12345"
 
         session.currentVisit = visit.copy(identifier = visitIdentifier)
-        session.visitStarted(visitIdentifier, true, "https://turbo.hotwired.dev")
+        session.visitStarted(
+            visitIdentifier = visitIdentifier,
+            visitHasCachedSnapshot = true,
+            visitIsPageRefresh = false,
+            location = "https://turbo.hotwired.dev"
+        )
 
         assertThat(session.currentVisit?.identifier).isEqualTo(visitIdentifier)
     }


### PR DESCRIPTION
Currently, when Turbo submits a form and redirects back to the same page, the current destination fragment is recreated. This displays a visual flash and doesn't work well with the upcoming Turbo 8 morphing feature.

To fix this, visit proposals for the same page are no longer proposed to the app. Instead, an immediate Turbo visit is started in the WebView so Turbo can seamlessly handle the visit and provide a better visual update with morphing.