### PR TITLE
Upgrade to SDK 34 and bump dependencies to latest versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.1.0'
+        classpath 'com.android.tools.build:gradle:8.1.4'
         classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.0'
     }
 }

--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -14,12 +14,12 @@ buildscript {
 }
 
 android {
-    compileSdkVersion 33
+    compileSdk 34
 
     defaultConfig {
         applicationId "dev.hotwire.turbo.demo"
-        minSdkVersion 24
-        targetSdkVersion 33
+        minSdkVersion 26
+        targetSdkVersion 34
         versionCode 1
         versionName "1.0"
         vectorDrawables.useSupportLibrary = true
@@ -65,10 +65,10 @@ android {
 
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
-    implementation 'com.google.android.material:material:1.9.0'
+    implementation 'com.google.android.material:material:1.10.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
-    implementation 'androidx.recyclerview:recyclerview:1.3.1'
-    implementation 'androidx.browser:browser:1.5.0'
+    implementation 'androidx.recyclerview:recyclerview:1.3.2'
+    implementation 'androidx.browser:browser:1.7.0'
     implementation 'org.jetbrains.kotlinx:kotlinx-serialization-json:1.5.0'
     implementation 'com.github.bumptech.glide:glide:4.15.1'
     implementation 'dev.hotwire:strada:1.0.0-beta2'

--- a/turbo/build.gradle
+++ b/turbo/build.gradle
@@ -34,7 +34,7 @@ android {
     testOptions.unitTests.includeAndroidResources = true
 
     defaultConfig {
-        minSdkVersion 24
+        minSdkVersion 26
         targetSdkVersion 34
 
         // Define ProGuard rules for this android library project. These rules will be applied when

--- a/turbo/build.gradle
+++ b/turbo/build.gradle
@@ -30,12 +30,12 @@ repositories {
 }
 
 android {
-    compileSdkVersion 33
+    compileSdk 34
     testOptions.unitTests.includeAndroidResources = true
 
     defaultConfig {
         minSdkVersion 24
-        targetSdkVersion 33
+        targetSdkVersion 34
 
         // Define ProGuard rules for this android library project. These rules will be applied when
         // a consumer of this library sets 'minifyEnabled true'.
@@ -72,8 +72,8 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'org.jetbrains.kotlin:kotlin-reflect:1.9.0'
-    implementation 'com.google.android.material:material:1.9.0'
+    implementation 'org.jetbrains.kotlin:kotlin-reflect:1.9.10'
+    implementation 'com.google.android.material:material:1.10.0'
 
     // AndroidX
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
@@ -93,16 +93,16 @@ dependencies {
 
     // Exported AndroidX dependencies
     api 'androidx.appcompat:appcompat:1.6.1'
-    api 'androidx.core:core-ktx:1.9.0'
-    api 'androidx.webkit:webkit:1.6.0'
-    api 'androidx.activity:activity-ktx:1.7.1'
-    api 'androidx.fragment:fragment-ktx:1.5.7'
-    api 'androidx.navigation:navigation-fragment-ktx:2.5.3'
-    api 'androidx.navigation:navigation-ui-ktx:2.5.3'
+    api 'androidx.core:core-ktx:1.12.0'
+    api 'androidx.webkit:webkit:1.8.0'
+    api 'androidx.activity:activity-ktx:1.8.1'
+    api 'androidx.fragment:fragment-ktx:1.6.2'
+    api 'androidx.navigation:navigation-fragment-ktx:2.7.5'
+    api 'androidx.navigation:navigation-ui-ktx:2.7.5'
 
     // Tests
     testImplementation 'androidx.test:core:1.5.0' // Robolectric
-    testImplementation 'androidx.navigation:navigation-testing:2.5.3'
+    testImplementation 'androidx.navigation:navigation-testing:2.7.5'
     testImplementation 'androidx.arch.core:core-testing:2.2.0'
     testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3'
     testImplementation 'org.assertj:assertj-core:3.24.2'


### PR DESCRIPTION
This PR:

- Updates the compile/target SDK to 34
- Upgrades the build tools to be compatible with SDK 34
- Bumps many `androidx.*` dependencies, which have some new features available