### PR TITLE
REPLACE_ROOT presentation - popUpTo to controller.graph.id (inclusive)

### DIFF
--- a/turbo/src/main/kotlin/dev/hotwire/turbo/nav/TurboNavRule.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/nav/TurboNavRule.kt
@@ -80,7 +80,7 @@ internal class TurboNavRule(
         // Use separate NavOptions if we need to pop up to the new root destination
         if (newPresentation == TurboNavPresentation.REPLACE_ROOT && newDestination != null) {
             return navOptions {
-                popUpTo(newDestination.id) { inclusive = true }
+                popUpTo(controller.graph.id) { inclusive = true }
             }
         }
 


### PR DESCRIPTION
# Issue

`replace_root` presentation may not remove all previous navigation items in the back stack.

Inclusive `popUpTo` pops every navigation items until it finds the given one, leaving previous navigation items stacked before it, depending of the previous navigation flow.

# Resolution

Popping up to the graph id ensures the back stack is fully cleared.
