### PR TITLE
Ensure that a snapshot is cached before navigating to a new location

### DIFF
--- a/turbo/src/main/assets/js/turbo_bridge.js
+++ b/turbo/src/main/assets/js/turbo_bridge.js
@@ -57,6 +57,12 @@
       }
     }
 
+    cacheSnapshot() {
+      if (window.Turbo) {
+        Turbo.session.view.cacheSnapshot()
+      }
+    }
+
     // Current visit
 
     issueRequestForVisitWithIdentifier(identifier) {

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/delegates/TurboWebFragmentDelegate.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/delegates/TurboWebFragmentDelegate.kt
@@ -110,6 +110,14 @@ internal class TurboWebFragmentDelegate(
     }
 
     /**
+     * Should be called by the implementing Fragment during
+     * [dev.hotwire.turbo.nav.TurboNavDestination.onBeforeNavigation]
+     */
+    fun onBeforeNavigation() {
+        session().cacheSnapshot(location)
+    }
+
+    /**
      * Provides a hook to Turbo when the dialog has been canceled. Detaches the WebView
      * before navigation.
      */

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/fragments/TurboWebFragment.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/fragments/TurboWebFragment.kt
@@ -66,6 +66,11 @@ abstract class TurboWebFragment : TurboFragment(), TurboWebFragmentCallback {
         }
     }
 
+    override fun onBeforeNavigation() {
+        super.onBeforeNavigation()
+        webDelegate.onBeforeNavigation()
+    }
+
     override fun refresh(displayProgress: Boolean) {
         webDelegate.refresh(displayProgress)
     }

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/session/TurboSession.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/session/TurboSession.kt
@@ -14,6 +14,7 @@ import androidx.webkit.WebResourceErrorCompat
 import androidx.webkit.WebViewClientCompat
 import androidx.webkit.WebViewCompat
 import androidx.webkit.WebViewFeature.*
+import dev.hotwire.turbo.config.Turbo
 import dev.hotwire.turbo.config.TurboPathConfiguration
 import dev.hotwire.turbo.config.screenshotsEnabled
 import dev.hotwire.turbo.delegates.TurboFileChooserDelegate
@@ -139,6 +140,13 @@ class TurboSession internal constructor(
             isColdBooting -> visitPending = true
             isReady -> visitLocation(visit)
             else -> visitLocationAsColdBoot(visit)
+        }
+    }
+
+    internal fun cacheSnapshot(location: String) {
+        if (this.currentVisit?.location == location) {
+            logEvent("cachingSnapshot", "location" to location)
+            webView.cacheSnapshot()
         }
     }
 

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/views/TurboWebView.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/views/TurboWebView.kt
@@ -59,6 +59,10 @@ open class TurboWebView @JvmOverloads constructor(context: Context, attrs: Attri
         runJavascript("turboNative.visitRenderedForColdBoot('$coldBootVisitIdentifier')")
     }
 
+    internal fun cacheSnapshot() {
+        runJavascript("turboNative.cacheSnapshot()")
+    }
+
     internal fun installBridge(onBridgeInstalled: () -> Unit) {
         val script = "window.turboNative == null"
         val bridge = context.contentFromAsset("js/turbo_bridge.js")


### PR DESCRIPTION
This is the Android counterpart to: https://github.com/hotwired/turbo-ios/pull/181

Prior to this PR it was possible that a snapshot was not cached for a given page when navigating away from a `WebView` screen. Replication steps:

1. Visit native screen `A`
2. Navigate to web screen `B`
3. Dismiss web screen `B` and navigate back to the native screen `A`
4. Navigate to web screen `B` again. There was no snapshot cache available.

This is due to the fact that, historically, snapshots were only cached by core `turbo.js` when navigating from web -> web screens. This resolves the issue by always caching a snapshot before navigating away from a web screen.