### PR TITLE
Properly handle navigate back/up from bottom sheet dialog fragments

### DIFF
--- a/turbo/src/main/kotlin/dev/hotwire/turbo/delegates/TurboFragmentDelegate.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/delegates/TurboFragmentDelegate.kt
@@ -97,10 +97,7 @@ class TurboFragmentDelegate(private val navDestination: TurboNavDestination) {
         navDestination.toolbarForNavigation()?.let {
             NavigationUI.setupWithNavController(it, fragment.findNavController())
             it.setNavigationOnClickListener {
-                when (fragment) {
-                    is DialogFragment -> fragment.requireDialog().cancel()
-                    else -> navDestination.navigateUp()
-                }
+                navDestination.navigateUp()
             }
         }
     }

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/nav/TurboNavigator.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/nav/TurboNavigator.kt
@@ -22,13 +22,21 @@ internal class TurboNavigator(private val navDestination: TurboNavDestination) {
 
     fun navigateUp() {
         onNavigationVisit {
-            currentController().navigateUp()
+            if (fragment is DialogFragment) {
+                fragment.requireDialog().cancel()
+            } else {
+                currentController().navigateUp()
+            }
         }
     }
 
     fun navigateBack() {
         onNavigationVisit {
-            currentController().popBackStack()
+            if (fragment is DialogFragment) {
+                fragment.requireDialog().cancel()
+            } else {
+                currentController().popBackStack()
+            }
         }
     }
 


### PR DESCRIPTION
To properly handle dismissing bottom sheet dialog fragments, it's necessary to cancel the `dialog` instance instead of popping the backstack to receive all the desired `Fragment` callbacks. Previously, calling `navigateBack()` or `navigateUp()` would dismiss the bottom sheet, but leave the underlying `WebView` screen stuck on a screenshot instead of the interactive attached `WebView`.

Fixes https://github.com/hotwired/turbo-android/issues/197