### PR TITLE
Fix `clearBackStack()` from a bottom sheet dialog fragment

### DIFF
--- a/turbo/src/main/kotlin/dev/hotwire/turbo/nav/TurboNavigator.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/nav/TurboNavigator.kt
@@ -95,6 +95,10 @@ internal class TurboNavigator(private val navDestination: TurboNavDestination) {
         }
 
         onNavigationVisit {
+            if (fragment is DialogFragment) {
+                fragment.requireDialog().cancel()
+            }
+
             val controller = currentController()
             controller.popBackStack(controller.graph.startDestinationId, false)
             onCleared()


### PR DESCRIPTION
Ensure that `clearBackStack()` works correctly when called from a bottom sheet fragment. Follow up to https://github.com/hotwired/turbo-android/pull/306

Fixes https://github.com/hotwired/turbo-android/issues/260