### PR TITLE
Allows error views to be scrolled without pull-to-refresh interference

### DIFF
--- a/turbo/src/main/res/layout/turbo_view.xml
+++ b/turbo/src/main/res/layout/turbo_view.xml
@@ -37,7 +37,7 @@
         android:visibility="gone"
         tools:ignore="ContentDescription" />
 
-    <dev.hotwire.turbo.views.TurboSwipeRefreshLayout
+    <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
         android:id="@+id/turbo_error_refresh"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
@@ -56,6 +56,6 @@
 
         </ScrollView>
 
-    </dev.hotwire.turbo.views.TurboSwipeRefreshLayout>
+    </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 
 </dev.hotwire.turbo.views.TurboView>


### PR DESCRIPTION
Fixes https://github.com/hotwired/turbo-android/issues/230