### PR TITLE
Fix `Toolbar` back button visibility without having a separate start destination `Fragment` instance

### DIFF
--- a/demo/src/main/kotlin/dev/hotwire/turbo/demo/features/imageviewer/ImageViewerFragment.kt
+++ b/demo/src/main/kotlin/dev/hotwire/turbo/demo/features/imageviewer/ImageViewerFragment.kt
@@ -10,7 +10,7 @@ import dev.hotwire.turbo.demo.R
 import dev.hotwire.turbo.fragments.TurboFragment
 import dev.hotwire.turbo.nav.TurboNavGraphDestination
 import com.bumptech.glide.Glide
-import dev.hotwire.turbo.demo.util.displayBackButtonAsCloseIcon
+import dev.hotwire.turbo.util.displayBackButtonAsCloseIcon
 
 @TurboNavGraphDestination(uri = "turbo://fragment/image_viewer")
 class ImageViewerFragment : TurboFragment(), NavDestination {

--- a/demo/src/main/kotlin/dev/hotwire/turbo/demo/features/web/WebModalFragment.kt
+++ b/demo/src/main/kotlin/dev/hotwire/turbo/demo/features/web/WebModalFragment.kt
@@ -1,18 +1,6 @@
 package dev.hotwire.turbo.demo.features.web
 
-import android.os.Bundle
-import android.view.View
-import dev.hotwire.turbo.demo.util.displayBackButtonAsCloseIcon
 import dev.hotwire.turbo.nav.TurboNavGraphDestination
 
 @TurboNavGraphDestination(uri = "turbo://fragment/web/modal")
-class WebModalFragment : WebFragment() {
-    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
-        initToolbar()
-    }
-
-    private fun initToolbar() {
-        toolbarForNavigation()?.displayBackButtonAsCloseIcon()
-    }
-}
+class WebModalFragment : WebFragment()

--- a/demo/src/main/kotlin/dev/hotwire/turbo/demo/util/Extensions.kt
+++ b/demo/src/main/kotlin/dev/hotwire/turbo/demo/util/Extensions.kt
@@ -17,10 +17,6 @@ import dev.hotwire.turbo.demo.strada.bridgeComponentFactories
 val TurboPathConfigurationProperties.description: String?
     get() = get("description")
 
-fun Toolbar.displayBackButtonAsCloseIcon() {
-    navigationIcon = ContextCompat.getDrawable(context, R.drawable.ic_close)
-}
-
 @Suppress("DEPRECATION")
 fun WebView.initDayNightTheme() {
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/delegates/TurboFragmentDelegate.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/delegates/TurboFragmentDelegate.kt
@@ -8,6 +8,8 @@ import dev.hotwire.turbo.nav.TurboNavDestination
 import dev.hotwire.turbo.nav.TurboNavigator
 import dev.hotwire.turbo.session.TurboSessionModalResult
 import dev.hotwire.turbo.session.TurboSessionViewModel
+import dev.hotwire.turbo.util.displayBackButton
+import dev.hotwire.turbo.util.displayBackButtonAsCloseIcon
 import dev.hotwire.turbo.util.logEvent
 
 /**
@@ -95,7 +97,14 @@ class TurboFragmentDelegate(private val navDestination: TurboNavDestination) {
 
     private fun initToolbar() {
         navDestination.toolbarForNavigation()?.let {
-            NavigationUI.setupWithNavController(it, fragment.findNavController())
+            if (!navigator.isAtStartDestination()) {
+                if (navDestination.isModal) {
+                    it.displayBackButtonAsCloseIcon()
+                } else {
+                    it.displayBackButton()
+                }
+            }
+
             it.setNavigationOnClickListener {
                 navDestination.navigateUp()
             }

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/nav/TurboNavDestination.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/nav/TurboNavDestination.kt
@@ -15,6 +15,7 @@ import androidx.navigation.navOptions
 import androidx.navigation.ui.R
 import dev.hotwire.turbo.config.TurboPathConfiguration
 import dev.hotwire.turbo.config.TurboPathConfigurationProperties
+import dev.hotwire.turbo.config.context
 import dev.hotwire.turbo.delegates.TurboFragmentDelegate
 import dev.hotwire.turbo.delegates.TurboNestedFragmentDelegate
 import dev.hotwire.turbo.fragments.TurboFragment
@@ -80,6 +81,12 @@ interface TurboNavDestination {
      */
     val isActive: Boolean
         get() = fragment.isAdded && !fragment.isDetached
+
+    /**
+     * Specifies whether the destination was presented in a modal context.
+     */
+    val isModal: Boolean
+        get() = pathProperties.context == TurboNavPresentationContext.MODAL
 
     /**
      * Gets the delegate instance that handles the Fragment's lifecycle events.

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/nav/TurboNavigator.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/nav/TurboNavigator.kt
@@ -20,6 +20,10 @@ internal class TurboNavigator(private val navDestination: TurboNavDestination) {
         onReady()
     }
 
+    fun isAtStartDestination(): Boolean {
+        return currentController().previousBackStackEntry == null
+    }
+
     fun navigateUp() {
         onNavigationVisit {
             if (fragment is DialogFragment) {
@@ -265,10 +269,6 @@ internal class TurboNavigator(private val navDestination: TurboNavDestination) {
 
     private fun currentControllerForLocation(location: String): NavController {
         return navDestination.navHostForNavigation(location).navController
-    }
-
-    private fun isAtStartDestination(): Boolean {
-        return currentController().previousBackStackEntry == null
     }
 
     private fun shouldNavigate(location: String): Boolean {

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/util/TurboExtensions.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/util/TurboExtensions.kt
@@ -5,13 +5,25 @@ import android.animation.ValueAnimator
 import android.content.Context
 import android.os.Handler
 import android.webkit.WebResourceRequest
+import androidx.appcompat.widget.Toolbar
+import androidx.core.content.ContextCompat
 import androidx.navigation.NavBackStackEntry
 import com.google.gson.Gson
 import com.google.gson.GsonBuilder
 import com.google.gson.reflect.TypeToken
+import dev.hotwire.turbo.R
 import dev.hotwire.turbo.visit.TurboVisitAction
 import dev.hotwire.turbo.visit.TurboVisitActionAdapter
 import java.io.File
+
+fun Toolbar.displayBackButton() {
+    navigationIcon = ContextCompat.getDrawable(context, R.drawable.ic_back)
+}
+
+fun Toolbar.displayBackButtonAsCloseIcon() {
+    navigationIcon = ContextCompat.getDrawable(context, R.drawable.ic_close)
+}
+
 
 internal fun Context.runOnUiThread(func: () -> Unit) {
     when (mainLooper.isCurrentThread) {

--- a/turbo/src/main/res/drawable/ic_back.xml
+++ b/turbo/src/main/res/drawable/ic_back.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M19,11H7.83l4.88,-4.88c0.39,-0.39 0.39,-1.03 0,-1.42 -0.39,-0.39 -1.02,-0.39 -1.41,0l-6.59,6.59c-0.39,0.39 -0.39,1.02 0,1.41l6.59,6.59c0.39,0.39 1.02,0.39 1.41,0 0.39,-0.39 0.39,-1.02 0,-1.41L7.83,13H19c0.55,0 1,-0.45 1,-1s-0.45,-1 -1,-1z"/>
+</vector>

--- a/turbo/src/main/res/drawable/ic_close.xml
+++ b/turbo/src/main/res/drawable/ic_close.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M19,6.41L17.59,5 12,10.59 6.41,5 5,6.41 10.59,12 5,17.59 6.41,19 12,13.41 17.59,19 19,17.59 13.41,12 19,6.41z"/>
+</vector>


### PR DESCRIPTION
Fixes https://github.com/hotwired/turbo-android/issues/188

It's no longer necessary to have a unique start destination `Fragment` instance from other destinations for the `Toolbar` back button to properly display.