### PR TITLE
Add Strada integration to WebBottomSheetFragment in demo

### DIFF
--- a/demo/src/main/kotlin/dev/hotwire/turbo/demo/features/web/WebBottomSheetFragment.kt
+++ b/demo/src/main/kotlin/dev/hotwire/turbo/demo/features/web/WebBottomSheetFragment.kt
@@ -2,16 +2,50 @@ package dev.hotwire.turbo.demo.features.web
 
 import android.os.Bundle
 import android.view.View
+import dev.hotwire.strada.BridgeDelegate
 import dev.hotwire.turbo.demo.R
 import dev.hotwire.turbo.demo.base.NavDestination
+import dev.hotwire.turbo.demo.strada.bridgeComponentFactories
 import dev.hotwire.turbo.fragments.TurboWebBottomSheetDialogFragment
 import dev.hotwire.turbo.nav.TurboNavGraphDestination
+import dev.hotwire.turbo.views.TurboWebView
 
 @TurboNavGraphDestination(uri = "turbo://fragment/web/modal/sheet")
 class WebBottomSheetFragment : TurboWebBottomSheetDialogFragment(), NavDestination {
+
+    private val bridgeDelegate by lazy {
+        BridgeDelegate(
+            location = location,
+            destination = this,
+            componentFactories =  bridgeComponentFactories
+        )
+    }
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         setupMenu()
+        viewLifecycleOwner.lifecycle.addObserver(bridgeDelegate)
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        viewLifecycleOwner.lifecycle.removeObserver(bridgeDelegate)
+    }
+
+    override fun onColdBootPageStarted(location: String) {
+        bridgeDelegate.onColdBootPageStarted()
+    }
+
+    override fun onColdBootPageCompleted(location: String) {
+        bridgeDelegate.onColdBootPageCompleted()
+    }
+
+    override fun onWebViewAttached(webView: TurboWebView) {
+        bridgeDelegate.onWebViewAttached(webView)
+    }
+
+    override fun onWebViewDetached(webView: TurboWebView) {
+        bridgeDelegate.onWebViewDetached()
     }
 
     override fun onFormSubmissionStarted(location: String) {


### PR DESCRIPTION
This is being done for completeness' sake. I used the demo as a source of truth for my Strada integration, but I needed to add a button to the menu in a bottom sheet. This did not work and had me scratching my head, wondering why it was not working, yet Strada was wired up correctly. Then I realized that `WebBottomSheetFragment` did not extend `WebFragment` so all the `BridgeDelegate` stuff was not set up in the bottom sheet. This adds this setup to the `WebBottomSheetFragment` in the demo so that others do not run into this issue as I did.

Could we abstract this away so it's not duplicated? Yeah, but I'm calling YAGNI at this point as it's a demo.