### PR TITLE
Add 402: Payment Required

### DIFF
--- a/turbo/src/main/kotlin/dev/hotwire/turbo/errors/HttpError.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/errors/HttpError.kt
@@ -23,6 +23,11 @@ sealed interface HttpError : TurboVisitError {
             override val reasonPhrase = "Unauthorized"
         }
 
+        data object PaymentRequired : ClientError {
+            override val statusCode = 402
+            override val reasonPhrase = "Payment Required"
+        }
+
         data object Forbidden : ClientError {
             override val statusCode = 403
             override val reasonPhrase = "Forbidden"

--- a/turbo/src/test/kotlin/dev/hotwire/turbo/errors/HttpErrorTest.kt
+++ b/turbo/src/test/kotlin/dev/hotwire/turbo/errors/HttpErrorTest.kt
@@ -18,6 +18,7 @@ class HttpErrorTest : BaseUnitTest() {
         val errors = listOf(
             400 to ClientError.BadRequest,
             401 to ClientError.Unauthorized,
+            402 to ClientError.PaymentRequired,
             403 to ClientError.Forbidden,
             404 to ClientError.NotFound,
             405 to ClientError.MethodNotAllowed,


### PR DESCRIPTION
Add missing 402 status code error handling. I'm using this status code to render native in-app purchase modals.