### PR TITLE
Only show error screens for SSL errors when the url matches the current visit

### DIFF
--- a/turbo/src/main/kotlin/dev/hotwire/turbo/session/TurboSession.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/session/TurboSession.kt
@@ -783,10 +783,12 @@ class TurboSession internal constructor(
             handler.cancel()
 
             val visitError = WebSslError.from(error)
+            logEvent("onReceivedSslError", "error" to visitError, "url" to error.url)
 
-            logEvent("onReceivedSslError", "error" to visitError)
-            reset()
-            callback { it.onReceivedError(visitError) }
+            if (currentVisit?.location == error.url) {
+                reset()
+                callback { it.onReceivedError(visitError) }
+            }
         }
 
         override fun onRenderProcessGone(view: WebView, detail: RenderProcessGoneDetail): Boolean {


### PR DESCRIPTION
This change prevents displaying an error view and resetting the session when a 3rd party resource is requested on a page with an SSL error. Error views should only be displayed when the main visit url fails to load from an SSL error.