### PR TITLE
Detect cross-origin visit request attempts

### DIFF
--- a/turbo/src/main/assets/js/turbo_bridge.js
+++ b/turbo/src/main/assets/js/turbo_bridge.js
@@ -179,6 +179,8 @@
     // Private
 
     async fetchFailedRequestCrossOriginRedirect(visit, statusCode) {
+      // Non-HTTP status codes are sent by Turbo for network
+      // failures, including cross-origin fetch redirect attempts.
       if (statusCode <= 0) {
         try {
           const response = await fetch(visit.location, { redirect: "follow" })

--- a/turbo/src/main/assets/js/turbo_bridge.js
+++ b/turbo/src/main/assets/js/turbo_bridge.js
@@ -98,18 +98,18 @@
     // Adapter interface
 
     visitProposedToLocation(location, options) {
-        if (window.Turbo && Turbo.navigator.locationWithActionIsSamePage(location, options.action)) {
-          // Scroll to the anchor on the page
-          TurboSession.visitProposalScrollingToAnchor(location.toString(), JSON.stringify(options))
-          Turbo.navigator.view.scrollToAnchorFromLocation(location)
-        } else if (window.Turbo && Turbo.navigator.location?.href === location.href) {
-          // Refresh the page without native proposal
-          TurboSession.visitProposalRefreshingPage(location.toString(), JSON.stringify(options))
-          this.visitLocationWithOptionsAndRestorationIdentifier(location, JSON.stringify(options), Turbo.navigator.restorationIdentifier)
-        } else {
-          // Propose the visit
-          TurboSession.visitProposedToLocation(location.toString(), JSON.stringify(options))
-        }
+      if (window.Turbo && Turbo.navigator.locationWithActionIsSamePage(location, options.action)) {
+        // Scroll to the anchor on the page
+        TurboSession.visitProposalScrollingToAnchor(location.toString(), JSON.stringify(options))
+        Turbo.navigator.view.scrollToAnchorFromLocation(location)
+      } else if (window.Turbo && Turbo.navigator.location?.href === location.href) {
+        // Refresh the page without native proposal
+        TurboSession.visitProposalRefreshingPage(location.toString(), JSON.stringify(options))
+        this.visitLocationWithOptionsAndRestorationIdentifier(location, JSON.stringify(options), Turbo.navigator.restorationIdentifier)
+      } else {
+        // Propose the visit
+        TurboSession.visitProposedToLocation(location.toString(), JSON.stringify(options))
+      }
     }
 
     // Turbolinks 5
@@ -134,8 +134,18 @@
       this.loadResponseForVisitWithIdentifier(visit.identifier)
     }
 
-    visitRequestFailedWithStatusCode(visit, statusCode) {
-      TurboSession.visitRequestFailedWithStatusCode(visit.identifier, visit.hasCachedSnapshot(), statusCode)
+    async visitRequestFailedWithStatusCode(visit, statusCode) {
+      // Turbo does not permit cross-origin fetch redirect attempts and
+      // they'll lead to a visit request failure. Attempt to see if the
+      // visit request failure was due to a cross-origin redirect.
+      const redirect = await this.fetchFailedRequestCrossOriginRedirect(visit, statusCode)
+      const location = visit.location.toString()
+
+      if (redirect != null) {
+        TurboSession.visitProposedToCrossOriginRedirect(location, redirect.toString(), visit.identifier)
+      } else {
+        TurboSession.visitRequestFailedWithStatusCode(location, visit.identifier, visit.hasCachedSnapshot(), statusCode)
+      }
     }
 
     visitRequestFinished(visit) {
@@ -167,6 +177,19 @@
     }
 
     // Private
+
+    async fetchFailedRequestCrossOriginRedirect(visit, statusCode) {
+      if (statusCode <= 0) {
+        try {
+          const response = await fetch(visit.location, { redirect: "follow" })
+          if (response.url != null && response.url.origin != visit.location.origin) {
+            return response.url
+          }
+        } catch {}
+      }
+
+      return null
+    }
 
     afterNextRepaint(callback) {
       if (document.hidden) {

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/delegates/TurboWebFragmentDelegate.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/delegates/TurboWebFragmentDelegate.kt
@@ -10,6 +10,7 @@ import androidx.lifecycle.findViewTreeLifecycleOwner
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.whenStateAtLeast
 import dev.hotwire.turbo.config.pullToRefreshEnabled
+import dev.hotwire.turbo.errors.TurboVisitError
 import dev.hotwire.turbo.fragments.TurboWebFragmentCallback
 import dev.hotwire.turbo.nav.TurboNavDestination
 import dev.hotwire.turbo.nav.TurboNavigator
@@ -21,7 +22,6 @@ import dev.hotwire.turbo.views.TurboView
 import dev.hotwire.turbo.views.TurboWebView
 import dev.hotwire.turbo.visit.TurboVisit
 import dev.hotwire.turbo.visit.TurboVisitAction
-import dev.hotwire.turbo.errors.TurboVisitError
 import dev.hotwire.turbo.visit.TurboVisitOptions
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -231,6 +231,13 @@ internal class TurboWebFragmentDelegate(
         options: TurboVisitOptions
     ) {
         navigator.navigate(location, options)
+    }
+
+    override fun visitProposedToCrossOriginRedirect(location: String) {
+        // Pop the current destination from the backstack since it
+        // resulted in a visit failure due to a cross-origin redirect.
+        navigator.navigateBack()
+        navigator.navigate(location, TurboVisitOptions())
     }
 
     override fun visitNavDestination(): TurboNavDestination {

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/session/TurboSessionCallback.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/session/TurboSessionCallback.kt
@@ -1,8 +1,8 @@
 package dev.hotwire.turbo.session
 
 import android.webkit.HttpAuthHandler
-import dev.hotwire.turbo.nav.TurboNavDestination
 import dev.hotwire.turbo.errors.TurboVisitError
+import dev.hotwire.turbo.nav.TurboNavDestination
 import dev.hotwire.turbo.visit.TurboVisitOptions
 
 internal interface TurboSessionCallback {
@@ -19,6 +19,7 @@ internal interface TurboSessionCallback {
     fun visitCompleted(completedOffline: Boolean)
     fun visitLocationStarted(location: String)
     fun visitProposedToLocation(location: String, options: TurboVisitOptions)
+    fun visitProposedToCrossOriginRedirect(location: String)
     fun visitNavDestination(): TurboNavDestination
     fun formSubmissionStarted(location: String)
     fun formSubmissionFinished(location: String)

--- a/turbo/src/test/kotlin/dev/hotwire/turbo/session/TurboSessionTest.kt
+++ b/turbo/src/test/kotlin/dev/hotwire/turbo/session/TurboSessionTest.kt
@@ -76,6 +76,17 @@ class TurboSessionTest {
     }
 
     @Test
+    fun visitProposedToCrossOriginRedirectFiresCallback() {
+        val location = "${visit.location}/page"
+        val redirectLocation = "https://example.com/page"
+
+        session.currentVisit = visit
+        session.visitProposedToCrossOriginRedirect(location, redirectLocation, visit.identifier)
+
+        verify(callback).visitProposedToCrossOriginRedirect(redirectLocation)
+    }
+
+    @Test
     fun visitStartedSavesCurrentVisitIdentifier() {
         val visitIdentifier = "12345"
 
@@ -105,7 +116,7 @@ class TurboSessionTest {
         val visitIdentifier = "12345"
 
         session.currentVisit = visit.copy(identifier = visitIdentifier)
-        session.visitRequestFailedWithStatusCode(visitIdentifier, true, 500)
+        session.visitRequestFailedWithStatusCode(visit.location, visitIdentifier, true, 500)
 
         verify(callback).requestFailedWithError(
             visitHasCachedSnapshot =  true,


### PR DESCRIPTION
The core `turbo.js` library does not permit cross-origin visit requests (i.e. a link that redirects to an external domain). These requests call the adapter method `visitRequestFailedWithStatusCode(visit, statusCode)` for all platforms. 

To handle this in the [browser adapter](https://github.com/hotwired/turbo/blob/main/src/core/native/browser_adapter.js#L41-L55), non-HTTP status code failures update the `window.location` so the browser can handle the top-level redirect. The browser adapter does not actually know whether a cross-origin redirect was attempted, since the CORS policy restricts requests to the `same-origin`, but updating the `window.location` directly bypasses needing this knowledge.

The mobile adapters, however, can't just update the `window.location` — a new visit needs to be proposed so the native app can decide how to handle the external url request. This PR finds any potential cross-origin redirect locations when a visit request fails with a non-HTTP status code and proposes the external redirect location as a new visit.

Fixes https://github.com/hotwired/turbo-android/issues/320
