### PR TITLE
Fix potential crash from HTTP logging interceptor

### DIFF
--- a/turbo/src/main/kotlin/dev/hotwire/turbo/http/TurboHttpClient.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/http/TurboHttpClient.kt
@@ -17,6 +17,9 @@ import java.util.concurrent.TimeUnit
 object TurboHttpClient {
     private var cache: Cache? = null
     private var httpCacheSize = 100L * 1024L * 1024L // 100 MBs
+    private val loggingInterceptor = HttpLoggingInterceptor().apply {
+        level = HttpLoggingInterceptor.Level.BASIC
+    }
 
     internal var instance = buildNewHttpClient()
 
@@ -63,9 +66,5 @@ object TurboHttpClient {
         }
 
         return builder.build()
-    }
-
-    private val loggingInterceptor = HttpLoggingInterceptor().apply {
-        level = HttpLoggingInterceptor.Level.BASIC
     }
 }


### PR DESCRIPTION
Ensure the `loggingInterceptor` is declared before any public functions can be called into the singleton instance.