### PR TITLE
Bump OkHttp to 4.12.0

### DIFF
--- a/turbo/build.gradle.kts
+++ b/turbo/build.gradle.kts
@@ -91,8 +91,8 @@ dependencies {
     implementation("com.google.code.gson:gson:2.10.1")
 
     // Networking/API
-    implementation("com.squareup.okhttp3:okhttp:4.11.0")
-    implementation("com.squareup.okhttp3:logging-interceptor:4.11.0")
+    implementation("com.squareup.okhttp3:okhttp:4.12.0")
+    implementation("com.squareup.okhttp3:logging-interceptor:4.12.0")
 
     // Coroutines
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3")
@@ -116,7 +116,7 @@ dependencies {
     testImplementation("org.robolectric:robolectric:4.9.2")
     testImplementation("org.mockito:mockito-core:5.2.0")
     testImplementation("com.nhaarman:mockito-kotlin:1.6.0")
-    testImplementation("com.squareup.okhttp3:mockwebserver:4.11.0")
+    testImplementation("com.squareup.okhttp3:mockwebserver:4.12.0")
     testImplementation("junit:junit:4.13.2")
 }
 


### PR DESCRIPTION
Resolves: https://github.com/hotwired/turbo-android/issues/328

Addresses security vulnerability: https://nvd.nist.gov/vuln/detail/CVE-2023-3635