### PR TITLE
Fix modal/empty history crash. 

### DIFF
--- a/turbo/src/main/kotlin/dev/hotwire/turbo/nav/TurboNavigator.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/nav/TurboNavigator.kt
@@ -147,7 +147,6 @@ internal class TurboNavigator(private val navDestination: TurboNavDestination) {
 
         when (rule.newPresentation) {
             TurboNavPresentation.REPLACE -> onNavigationVisit {
-                popBackStack(rule)
                 navigateToLocation(rule)
             }
             else -> onNavigationVisit {


### PR DESCRIPTION
Do not pop history from stack when opening a modal.