### PR TITLE
Path Configuration parsing fix

### DIFF
--- a/turbo/src/main/kotlin/dev/hotwire/turbo/config/TurboPathConfigurationLoader.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/config/TurboPathConfigurationLoader.kt
@@ -29,11 +29,9 @@ internal class TurboPathConfigurationLoader(val context: Context) : CoroutineSco
         loadCachedConfigurationForUrl(url, onCompletion)
 
         launch {
-            repository.getRemoteConfiguration(url)?.let { remoteConfigJson ->
-                repository.parseFromJson(remoteConfigJson)?.let { config ->
-                    onCompletion(config)
-                    cacheConfigurationForUrl(url, config)
-                }
+            repository.getRemoteConfiguration(url)?.let { config ->
+                onCompletion(config)
+                cacheConfigurationForUrl(url, config)
             }
         }
     }

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/config/TurboPathConfigurationLoader.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/config/TurboPathConfigurationLoader.kt
@@ -1,6 +1,7 @@
 package dev.hotwire.turbo.config
 
 import android.content.Context
+import dev.hotwire.turbo.config.Turbo.config
 import dev.hotwire.turbo.util.dispatcherProvider
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
@@ -38,17 +39,14 @@ internal class TurboPathConfigurationLoader(val context: Context) : CoroutineSco
     }
 
     private fun loadBundledAssetConfiguration(filePath: String, onCompletion: (TurboPathConfiguration) -> Unit) {
-        val bundledConfigJson = repository.getBundledConfiguration(context, filePath)
-        repository.parseFromJson(bundledConfigJson)?.let { config ->
+        repository.getBundledConfiguration(context, filePath)?.let { config ->
             onCompletion(config)
         }
     }
 
     private fun loadCachedConfigurationForUrl(url: String, onCompletion: (TurboPathConfiguration) -> Unit) {
-        repository.getCachedConfigurationForUrl(context, url)?.let { cachedConfigJson ->
-            repository.parseFromJson(cachedConfigJson)?.let { config ->
-                onCompletion(config)
-            }
+        repository.getCachedConfigurationForUrl(context, url)?.let { config ->
+            onCompletion(config)
         }
     }
 

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/config/TurboPathConfigurationRepository.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/config/TurboPathConfigurationRepository.kt
@@ -2,6 +2,7 @@ package dev.hotwire.turbo.config
 
 import android.content.Context
 import android.content.SharedPreferences
+import androidx.annotation.VisibleForTesting
 import androidx.core.content.edit
 import com.google.gson.reflect.TypeToken
 import dev.hotwire.turbo.http.TurboHttpClient
@@ -23,12 +24,14 @@ internal class TurboPathConfigurationRepository {
         }
     }
 
-    fun getBundledConfiguration(context: Context, filePath: String): String {
-        return contentFromAsset(context, filePath)
+    fun getBundledConfiguration(context: Context, filePath: String): TurboPathConfiguration? {
+        val bundledConfigJson = contentFromAsset(context, filePath)
+        return parseFromJson(bundledConfigJson)
     }
 
-    fun getCachedConfigurationForUrl(context: Context, url: String): String? {
-        return prefs(context).getString(url, null)
+    fun getCachedConfigurationForUrl(context: Context, url: String): TurboPathConfiguration? {
+        val cachedConfigJson = prefs(context).getString(url, null)
+        return cachedConfigJson?.let { parseFromJson(it) }
     }
 
     fun cacheConfigurationForUrl(context: Context, url: String, pathConfiguration: TurboPathConfiguration) {
@@ -68,6 +71,7 @@ internal class TurboPathConfigurationRepository {
         }
     }
 
+    @VisibleForTesting
     fun parseFromJson(json: String): TurboPathConfiguration? {
         return try {
             json.toObject(object : TypeToken<TurboPathConfiguration>() {})

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/config/TurboPathConfigurationRepository.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/config/TurboPathConfigurationRepository.kt
@@ -3,13 +3,14 @@ package dev.hotwire.turbo.config
 import android.content.Context
 import android.content.SharedPreferences
 import androidx.core.content.edit
+import com.google.gson.reflect.TypeToken
 import dev.hotwire.turbo.http.TurboHttpClient
 import dev.hotwire.turbo.util.dispatcherProvider
 import dev.hotwire.turbo.util.logError
 import dev.hotwire.turbo.util.toJson
+import dev.hotwire.turbo.util.toObject
 import kotlinx.coroutines.withContext
 import okhttp3.Request
-import java.io.IOException
 
 internal class TurboPathConfigurationRepository {
     private val cacheFile = "turbo"
@@ -64,6 +65,15 @@ internal class TurboPathConfigurationRepository {
     private fun contentFromAsset(context: Context, filePath: String): String {
         return context.assets.open(filePath).use {
             String(it.readBytes())
+        }
+    }
+
+    fun parseFromJson(json: String): TurboPathConfiguration? {
+        return try {
+            json.toObject(object : TypeToken<TurboPathConfiguration>() {})
+        } catch (e: Exception) {
+            logError("PathConfigurationLoadingException", e)
+            null
         }
     }
 }

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/config/TurboPathConfigurationRepository.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/config/TurboPathConfigurationRepository.kt
@@ -16,11 +16,11 @@ import okhttp3.Request
 internal class TurboPathConfigurationRepository {
     private val cacheFile = "turbo"
 
-    suspend fun getRemoteConfiguration(url: String): String? {
+    suspend fun getRemoteConfiguration(url: String): TurboPathConfiguration? {
         val request = Request.Builder().url(url).build()
 
         return withContext(dispatcherProvider.io) {
-            issueRequest(request)
+            issueRequest(request)?.let { parseFromJson(it) }
         }
     }
 

--- a/turbo/src/test/kotlin/dev/hotwire/turbo/config/TurboPathConfigurationRepositoryTest.kt
+++ b/turbo/src/test/kotlin/dev/hotwire/turbo/config/TurboPathConfigurationRepositoryTest.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.os.Build
 import androidx.test.core.app.ApplicationProvider
 import dev.hotwire.turbo.BaseRepositoryTest
+import dev.hotwire.turbo.config.Turbo.config
 import dev.hotwire.turbo.http.TurboHttpClient
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -60,10 +61,9 @@ class TurboPathConfigurationRepositoryTest : BaseRepositoryTest() {
 
     @Test
     fun getBundledAssetConfiguration() {
-        val json = repository.getBundledConfiguration(context, "json/test-configuration.json")
-        assertThat(json).isNotNull()
+        val config = repository.getBundledConfiguration(context, "json/test-configuration.json")
+        assertThat(config).isNotNull()
 
-        val config = repository.parseFromJson(json)
         assertThat(config?.rules?.size).isEqualTo(10)
     }
 
@@ -73,10 +73,9 @@ class TurboPathConfigurationRepositoryTest : BaseRepositoryTest() {
         val config = requireNotNull(repository.parseFromJson(json()))
         repository.cacheConfigurationForUrl(context, url, config)
 
-        val json = repository.getCachedConfigurationForUrl(context, url)
-        assertThat(json).isNotNull()
+        val cachedConfig = repository.getCachedConfigurationForUrl(context, url)
+        assertThat(cachedConfig).isNotNull()
 
-        val cachedConfig = repository.parseFromJson(json!!)
         assertThat(cachedConfig?.rules?.size).isEqualTo(1)
     }
 

--- a/turbo/src/test/kotlin/dev/hotwire/turbo/config/TurboPathConfigurationRepositoryTest.kt
+++ b/turbo/src/test/kotlin/dev/hotwire/turbo/config/TurboPathConfigurationRepositoryTest.kt
@@ -35,10 +35,8 @@ class TurboPathConfigurationRepositoryTest : BaseRepositoryTest() {
 
         runBlocking {
             launch(Dispatchers.Main) {
-                val json = repository.getRemoteConfiguration(baseUrl())
-                assertThat(json).isNotNull()
-
-                val config = repository.parseFromJson(json!!)
+                val config = repository.getRemoteConfiguration(baseUrl())
+                assertThat(config).isNotNull()
                 assertThat(config?.rules?.size).isEqualTo(2)
             }
         }
@@ -50,10 +48,7 @@ class TurboPathConfigurationRepositoryTest : BaseRepositoryTest() {
 
         runBlocking {
             launch(Dispatchers.Main) {
-                val json = repository.getRemoteConfiguration(baseUrl())
-                assertThat(json).isNotNull()
-
-                val config = repository.parseFromJson(json!!)
+                val config = repository.getRemoteConfiguration(baseUrl())
                 assertThat(config).isNull()
             }
         }

--- a/turbo/src/test/resources/http-responses/test-configuration-malformed.json
+++ b/turbo/src/test/resources/http-responses/test-configuration-malformed.json
@@ -1,0 +1,1 @@
+Not a valid path configuration


### PR DESCRIPTION
When the Turbo Path Configuration file is malformed or in a wrong format, parsing it from JSON can result in an exception being thrown. This PR adds checks and error handling for such cases.