### PR TITLE
Backport the ability to fix same page restores from `hotwire-native-android`

### DIFF
--- a/turbo/src/main/assets/js/turbo_bridge.js
+++ b/turbo/src/main/assets/js/turbo_bridge.js
@@ -39,7 +39,16 @@
       let action = options.action
 
       if (window.Turbo) {
-        if (Turbo.navigator.locationWithActionIsSamePage(new URL(location), action)) {
+        if (Turbo.navigator.location?.href === location && action === "restore") {
+          // A "restore" visit to the currently rendered location can occur when visiting
+          // a web -> native -> back to web screen. In this situation, the connect()
+          // callback (from Stimulus) in bridge component controllers will not be called,
+          // since they are already connected. We need to notify the web bridge library
+          // that a "restore" visit has occurred to manually trigger connect() and notify
+          // the native app so the native bridge component view state can be restored.
+          Turbo.navigator.startVisit(location, restorationIdentifier, options)
+          document.dispatchEvent(new Event("native:restore"))
+        } else if (Turbo.navigator.locationWithActionIsSamePage(new URL(location), action)) {
           // Skip the same-page anchor scrolling behavior for visits initiated from the native
           // side. The page content may be stale and we want a fresh request from the network.
           Turbo.navigator.startVisit(location, restorationIdentifier, { "action": "replace" })
@@ -54,6 +63,12 @@
           // Turbolinks 5.3
           Turbolinks.controller.startVisitToLocation(location, restorationIdentifier, options)
         }
+      }
+    }
+
+    cacheSnapshot() {
+      if (window.Turbo) {
+        Turbo.session.view.cacheSnapshot()
       }
     }
 

--- a/turbo/src/main/assets/js/turbo_bridge.js
+++ b/turbo/src/main/assets/js/turbo_bridge.js
@@ -39,16 +39,7 @@
       let action = options.action
 
       if (window.Turbo) {
-        if (Turbo.navigator.location?.href === location && action === "restore") {
-          // A "restore" visit to the currently rendered location can occur when visiting
-          // a web -> native -> back to web screen. In this situation, the connect()
-          // callback (from Stimulus) in bridge component controllers will not be called,
-          // since they are already connected. We need to notify the web bridge library
-          // that a "restore" visit has occurred to manually trigger connect() and notify
-          // the native app so the native bridge component view state can be restored.
-          Turbo.navigator.startVisit(location, restorationIdentifier, options)
-          document.dispatchEvent(new Event("native:restore"))
-        } else if (Turbo.navigator.locationWithActionIsSamePage(new URL(location), action)) {
+        if (Turbo.navigator.locationWithActionIsSamePage(new URL(location), action)) {
           // Skip the same-page anchor scrolling behavior for visits initiated from the native
           // side. The page content may be stale and we want a fresh request from the network.
           Turbo.navigator.startVisit(location, restorationIdentifier, { "action": "replace" })
@@ -64,6 +55,16 @@
           Turbolinks.controller.startVisitToLocation(location, restorationIdentifier, options)
         }
       }
+    }
+
+    restoreCurrentVisit() {
+      // A synthetic "restore" visit to the currently rendered location can occur when
+      // visiting a web -> native -> back to web screen. In this situation, the connect()
+      // callback (from Stimulus) in bridge component controllers will not be called,
+      // since they are already connected. We need to notify the web bridge library
+      // that the webview has been reattached to manually trigger connect() and notify
+      // the native app so the native bridge component view state can be restored.
+      document.dispatchEvent(new Event("native:restore"))
     }
 
     cacheSnapshot() {

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/delegates/TurboWebFragmentDelegate.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/delegates/TurboWebFragmentDelegate.kt
@@ -341,9 +341,15 @@ internal class TurboWebFragmentDelegate(
 
             // Visit every time the WebView is reattached to the current Fragment.
             if (isWebViewAttachedToNewDestination) {
-                showProgressView(location)
-                visit(location, restoreWithCachedSnapshot = !isInitialVisit, reload = false)
-                isInitialVisit = false
+                val currentSessionVisitRestored = !isInitialVisit &&
+                        session().currentVisit?.destinationIdentifier == identifier &&
+                        session().restoreCurrentVisit(this)
+
+                if (!currentSessionVisitRestored) {
+                    showProgressView(location)
+                    visit(location, restoreWithCachedSnapshot = !isInitialVisit, reload = false)
+                    isInitialVisit = false
+                }
             }
         }
     }

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/delegates/TurboWebFragmentDelegate.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/delegates/TurboWebFragmentDelegate.kt
@@ -18,6 +18,7 @@ import dev.hotwire.turbo.session.TurboSession
 import dev.hotwire.turbo.session.TurboSessionCallback
 import dev.hotwire.turbo.session.TurboSessionModalResult
 import dev.hotwire.turbo.util.dispatcherProvider
+import dev.hotwire.turbo.util.location
 import dev.hotwire.turbo.views.TurboView
 import dev.hotwire.turbo.views.TurboWebView
 import dev.hotwire.turbo.visit.TurboVisit
@@ -129,6 +130,24 @@ internal class TurboWebFragmentDelegate(
         if (webViewIsAttached()) {
             session().removeCallback(this)
             detachWebView()
+        }
+    }
+
+    /**
+     * Should be called by the implementing Fragment during
+     * [androidx.fragment.app.Fragment.onDestroyView].
+     */
+    fun onDestroyView() {
+        // Manually cache a snapshot of the WebView when navigating from a
+        // web screen to a native screen. This allows a "restore" visit when
+        // revisiting this location again.
+
+        val navHost = navDestination.sessionNavHostFragment
+        val currentBackStackEntry = navHost.navController.currentBackStackEntry
+        val currentLocation = currentBackStackEntry?.location
+
+        if (session().currentVisit?.location != currentLocation) {
+            session().cacheSnapshot()
         }
     }
 
@@ -322,15 +341,9 @@ internal class TurboWebFragmentDelegate(
 
             // Visit every time the WebView is reattached to the current Fragment.
             if (isWebViewAttachedToNewDestination) {
-                val currentSessionVisitRestored = !isInitialVisit &&
-                    session().currentVisit?.destinationIdentifier == identifier &&
-                    session().restoreCurrentVisit(this)
-
-                if (!currentSessionVisitRestored) {
-                    showProgressView(location)
-                    visit(location, restoreWithCachedSnapshot = !isInitialVisit, reload = false)
-                    isInitialVisit = false
-                }
+                showProgressView(location)
+                visit(location, restoreWithCachedSnapshot = !isInitialVisit, reload = false)
+                isInitialVisit = false
             }
         }
     }

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/fragments/TurboWebBottomSheetDialogFragment.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/fragments/TurboWebBottomSheetDialogFragment.kt
@@ -40,6 +40,11 @@ abstract class TurboWebBottomSheetDialogFragment : TurboBottomSheetDialogFragmen
         webDelegate.onViewCreated()
     }
 
+    override fun onDestroyView() {
+        super.onDestroyView()
+        webDelegate.onDestroyView()
+    }
+
     override fun activityResultLauncher(requestCode: Int): ActivityResultLauncher<Intent>? {
         return when (requestCode) {
             TURBO_REQUEST_CODE_FILES -> webDelegate.fileChooserResultLauncher

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/fragments/TurboWebFragment.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/fragments/TurboWebFragment.kt
@@ -9,11 +9,11 @@ import android.view.ViewGroup
 import androidx.activity.result.ActivityResultLauncher
 import dev.hotwire.turbo.R
 import dev.hotwire.turbo.delegates.TurboWebFragmentDelegate
+import dev.hotwire.turbo.errors.TurboVisitError
 import dev.hotwire.turbo.session.TurboSessionModalResult
 import dev.hotwire.turbo.util.TURBO_REQUEST_CODE_FILES
 import dev.hotwire.turbo.views.TurboView
 import dev.hotwire.turbo.views.TurboWebChromeClient
-import dev.hotwire.turbo.errors.TurboVisitError
 
 /**
  * The base class from which all web "standard" fragments (non-dialogs) in a
@@ -36,6 +36,11 @@ abstract class TurboWebFragment : TurboFragment(), TurboWebFragmentCallback {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         webDelegate.onViewCreated()
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        webDelegate.onDestroyView()
     }
 
     override fun onStart() {

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/session/TurboSession.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/session/TurboSession.kt
@@ -159,6 +159,34 @@ class TurboSession internal constructor(
     }
 
     /**
+     * Synthetically restore the WebView's current visit without using a cached snapshot or a
+     * visit request. This is used when restoring a Fragment destination from the backstack,
+     * but the WebView's current location hasn't changed from the destination's location.
+     */
+    internal fun restoreCurrentVisit(callback: TurboSessionCallback): Boolean {
+        val visit = currentVisit ?: return false
+        val restorationIdentifier = restorationIdentifiers[visit.destinationIdentifier]
+
+        if (!isReady || restorationIdentifier == null) {
+            return false
+        }
+
+        logEvent("restoreCurrentVisit",
+            "location" to visit.location,
+            "visitIdentifier" to visit.identifier,
+            "restorationIdentifier" to restorationIdentifier
+        )
+
+        visit.callback = callback
+        visitRendered(visit.identifier)
+        visitCompleted(visit.identifier, restorationIdentifier)
+
+        webView.restoreCurrentVisit()
+
+        return true
+    }
+
+    /**
      * Cache a snapshot of the current visit.
      */
     fun cacheSnapshot() {

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/views/TurboWebView.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/views/TurboWebView.kt
@@ -60,6 +60,10 @@ open class TurboWebView @JvmOverloads constructor(context: Context, attrs: Attri
         runJavascript("turboNative.visitRenderedForColdBoot('$coldBootVisitIdentifier')")
     }
 
+    internal fun cacheSnapshot() {
+        runJavascript("turboNative.cacheSnapshot()")
+    }
+
     internal fun installBridge(onBridgeInstalled: () -> Unit) {
         val script = "window.turboNative == null"
         val bridge = context.contentFromAsset("js/turbo_bridge.js")

--- a/turbo/src/main/kotlin/dev/hotwire/turbo/views/TurboWebView.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/views/TurboWebView.kt
@@ -64,6 +64,10 @@ open class TurboWebView @JvmOverloads constructor(context: Context, attrs: Attri
         runJavascript("turboNative.cacheSnapshot()")
     }
 
+    internal fun restoreCurrentVisit() {
+        runJavascript("turboNative.restoreCurrentVisit()")
+    }
+
     internal fun installBridge(onBridgeInstalled: () -> Unit) {
         val script = "window.turboNative == null"
         val bridge = context.contentFromAsset("js/turbo_bridge.js")

--- a/turbo/src/test/kotlin/dev/hotwire/turbo/session/TurboSessionTest.kt
+++ b/turbo/src/test/kotlin/dev/hotwire/turbo/session/TurboSessionTest.kt
@@ -2,8 +2,6 @@ package dev.hotwire.turbo.session
 
 import android.os.Build
 import androidx.appcompat.app.AppCompatActivity
-import com.nhaarman.mockito_kotlin.never
-import com.nhaarman.mockito_kotlin.times
 import com.nhaarman.mockito_kotlin.whenever
 import dev.hotwire.turbo.errors.HttpError.ServerError
 import dev.hotwire.turbo.errors.LoadError
@@ -203,44 +201,6 @@ class TurboSessionTest {
 
         assertThat(session.coldBootVisitIdentifier).isEmpty()
         assertThat(session.currentVisit?.identifier).isEmpty()
-    }
-
-    @Test
-    fun restoreCurrentVisit() {
-        val visitIdentifier = "12345"
-        val restorationIdentifier = "67890"
-
-        session.currentVisit = visit.copy(identifier = visitIdentifier)
-        session.turboIsReady(true)
-        session.pageLoaded(restorationIdentifier)
-
-        assertThat(session.restoreCurrentVisit(callback)).isTrue()
-        verify(callback, times(2)).visitCompleted(false)
-    }
-
-    @Test
-    fun restoreCurrentVisitFailsWithNoRestorationIdentifier() {
-        val visitIdentifier = "12345"
-
-        session.currentVisit = visit.copy(identifier = visitIdentifier)
-        session.turboIsReady(true)
-
-        assertThat(session.restoreCurrentVisit(callback)).isFalse()
-        verify(callback, times(1)).visitCompleted(false)
-    }
-
-    @Test
-    fun restoreCurrentVisitFailsWithSessionNotReady() {
-        val visitIdentifier = "12345"
-        val restorationIdentifier = "67890"
-
-        session.currentVisit = visit.copy(identifier = visitIdentifier)
-        session.pageLoaded(restorationIdentifier)
-        session.turboIsReady(false)
-
-        assertThat(session.restoreCurrentVisit(callback)).isFalse()
-        verify(callback, never()).visitCompleted(false)
-        verify(callback).requestFailedWithError(false, LoadError.NotReady)
     }
 
     @Test

--- a/turbo/src/test/kotlin/dev/hotwire/turbo/session/TurboSessionTest.kt
+++ b/turbo/src/test/kotlin/dev/hotwire/turbo/session/TurboSessionTest.kt
@@ -2,6 +2,8 @@ package dev.hotwire.turbo.session
 
 import android.os.Build
 import androidx.appcompat.app.AppCompatActivity
+import com.nhaarman.mockito_kotlin.never
+import com.nhaarman.mockito_kotlin.times
 import com.nhaarman.mockito_kotlin.whenever
 import dev.hotwire.turbo.errors.HttpError.ServerError
 import dev.hotwire.turbo.errors.LoadError
@@ -201,6 +203,45 @@ class TurboSessionTest {
 
         assertThat(session.coldBootVisitIdentifier).isEmpty()
         assertThat(session.currentVisit?.identifier).isEmpty()
+    }
+
+    @Test
+    fun restoreCurrentVisit() {
+        val visitIdentifier = "12345"
+        val restorationIdentifier = "67890"
+
+        session.currentVisit = visit.copy(identifier = visitIdentifier)
+        session.turboIsReady(true)
+        session.pageLoaded(restorationIdentifier)
+
+        assertThat(session.restoreCurrentVisit(callback)).isTrue()
+        verify(callback, times(2)).visitCompleted(false)
+        verify(webView, times(1)).restoreCurrentVisit()
+    }
+
+    @Test
+    fun restoreCurrentVisitFailsWithNoRestorationIdentifier() {
+        val visitIdentifier = "12345"
+
+        session.currentVisit = visit.copy(identifier = visitIdentifier)
+        session.turboIsReady(true)
+
+        assertThat(session.restoreCurrentVisit(callback)).isFalse()
+        verify(callback, times(1)).visitCompleted(false)
+    }
+
+    @Test
+    fun restoreCurrentVisitFailsWithSessionNotReady() {
+        val visitIdentifier = "12345"
+        val restorationIdentifier = "67890"
+
+        session.currentVisit = visit.copy(identifier = visitIdentifier)
+        session.pageLoaded(restorationIdentifier)
+        session.turboIsReady(false)
+
+        assertThat(session.restoreCurrentVisit(callback)).isFalse()
+        verify(callback, never()).visitCompleted(false)
+        verify(callback).requestFailedWithError(false, LoadError.NotReady)
     }
 
     @Test


### PR DESCRIPTION
This backports the functionality in https://github.com/hotwired/hotwire-native-android/pull/160. See the Hotwire Native PR for details.