### PR TITLE
Validate deep link args when resolving the start location

### DIFF
--- a/turbo/src/main/kotlin/dev/hotwire/turbo/session/TurboSessionNavHostFragment.kt
+++ b/turbo/src/main/kotlin/dev/hotwire/turbo/session/TurboSessionNavHostFragment.kt
@@ -17,6 +17,7 @@ import dev.hotwire.turbo.views.TurboWebView
 import kotlin.reflect.KClass
 
 internal const val DEEPLINK_EXTRAS_KEY = "android-support-nav:controller:deepLinkExtras"
+internal const val DEEPLINK_ARGS_KEY = "android-support-nav:controller:deepLinkArgs"
 internal const val LOCATION_KEY = "location"
 
 abstract class TurboSessionNavHostFragment : NavHostFragment() {
@@ -114,14 +115,22 @@ abstract class TurboSessionNavHostFragment : NavHostFragment() {
             ?: throw IllegalStateException("No current destination found in NavHostFragment")
 
     /**
-     * Google's Navigation library automatically navigates to deep links provided in the
-     * Activity's Intent. This exposes a vulnerability for malicious Intents to open an arbitrary
-     * webpage outside of the app's domain, allowing javascript injection on the page. Ensure
-     * that deep link intents always match the app's domain.
+     * Google's Navigation library automatically navigates to deep links provided in the launching
+     * Intent, which lets a malicious Intent open an arbitrary page in the WebView. Sanitize the
+     * Intent's attacker-controllable deep-link arguments so the start location stays within the
+     * app's domain.
      */
     @VisibleForTesting
     internal fun ensureDeeplinkStartLocationValid(activity: FragmentActivity) {
-        val extrasBundle = activity.intent.extras?.getBundle(DEEPLINK_EXTRAS_KEY) ?: return
+        val intent = activity.intent
+
+        // NavController merges deepLinkArgs over the validated deepLinkExtras (last write wins), so
+        // empty each per-destination bundle to stop it overriding the validated start location.
+        intent.extras?.getParcelableArrayList<Bundle>(DEEPLINK_ARGS_KEY)?.let { args ->
+            intent.putParcelableArrayListExtra(DEEPLINK_ARGS_KEY, ArrayList(args.map { Bundle() }))
+        }
+
+        val extrasBundle = intent.extras?.getBundle(DEEPLINK_EXTRAS_KEY) ?: return
         val startLocationFromIntent = extrasBundle.getString(LOCATION_KEY) ?: return
 
         val deepLinkStartUri = startLocationFromIntent.toUri()
@@ -129,7 +138,7 @@ abstract class TurboSessionNavHostFragment : NavHostFragment() {
 
         if (deepLinkStartUri.host != configStartUri.host) {
             extrasBundle.putString(LOCATION_KEY, startLocation)
-            activity.intent.putExtra(DEEPLINK_EXTRAS_KEY, extrasBundle)
+            intent.putExtra(DEEPLINK_EXTRAS_KEY, extrasBundle)
         }
     }
 

--- a/turbo/src/test/kotlin/dev/hotwire/turbo/session/TurboSessionNavHostFragmentTest.kt
+++ b/turbo/src/test/kotlin/dev/hotwire/turbo/session/TurboSessionNavHostFragmentTest.kt
@@ -2,6 +2,7 @@ package dev.hotwire.turbo.session
 
 import android.content.Intent
 import android.os.Build
+import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
@@ -52,6 +53,28 @@ class TurboSessionNavHostFragmentTest : BaseUnitTest() {
 
         val resultBundle = activity.intent.getBundleExtra(DEEPLINK_EXTRAS_KEY)
         assertThat(resultBundle?.getString(LOCATION_KEY)).isEqualTo("https://example.com/path")
+    }
+
+    // NavController merges deepLinkArgs over deepLinkExtras (last write wins); the intent's args
+    // must not survive to override the validated start location.
+    @Test
+    fun `empties deepLinkArgs so they cannot override the start location`() {
+        val intent = Intent().apply {
+            putExtra(DEEPLINK_EXTRAS_KEY, bundleOf(LOCATION_KEY to "https://example.com/ok"))
+            putParcelableArrayListExtra(DEEPLINK_ARGS_KEY, arrayListOf(bundleOf(LOCATION_KEY to ATTACKER_URL)))
+        }
+        activity = Robolectric.buildActivity(TestActivity::class.java, intent).create().get()
+
+        host = TestNavHostFragment()
+        host.ensureDeeplinkStartLocationValid(activity)
+
+        val survivingArgs = activity.intent.getParcelableArrayListExtra<Bundle>(DEEPLINK_ARGS_KEY)
+            ?.mapNotNull { it.getString(LOCATION_KEY) }.orEmpty()
+        assertThat(survivingArgs).doesNotContain(ATTACKER_URL)
+    }
+
+    companion object {
+        private const val ATTACKER_URL = "https://attacker.example/steal"
     }
 
 }


### PR DESCRIPTION
## Problem

`TurboSessionNavHostFragment.ensureDeeplinkStartLocationValid()` validates the start `location` only inside the `deepLinkExtras` intent extra (`android-support-nav:controller:deepLinkExtras`).

AndroidX `NavController` also reads a second extra — `deepLinkArgs` (`android-support-nav:controller:deepLinkArgs`) — and merges it *over* `deepLinkExtras` when assembling each destination's arguments (`arguments.putAll(globalArgs)` followed by `arguments.putAll(deepLinkArgs[index])`, so the later write wins). Because an exported Activity's launch intent is externally controllable, a `location` (or any other argument) supplied via `deepLinkArgs` overrides the validated value and becomes the session's start destination — loading an unvalidated URL into the host's WebView.

This ports hotwired/hotwire-native-android#200 to turbo-android.

## Fix

`ensureDeeplinkStartLocationValid()` now sanitizes the launching intent's `deepLinkArgs` in addition to validating `deepLinkExtras`:

- each `deepLinkArgs` per-destination bundle is emptied so it can't override the validated start location;
- a `deepLinkExtras` start `location` whose host doesn't match the configured start host is reverted to the configured start location, as before.

Sanitization applies to every launching intent. Intent-origin signals are too weak to gate on — `callingPackage` is only set for `startActivityForResult` launches, and `Activity.referrer` is backed by the attacker-settable `EXTRA_REFERRER` — so there is no reliable way to distinguish app-produced intents from external ones. Unconditional sanitization keeps legitimate same-host start locations working while preventing an external intent from steering the session to an arbitrary URL.

## Tests

`TurboSessionNavHostFragmentTest` covers:
- an off-host start location is reverted to the configured one;
- a same-host start location is preserved;
- `deepLinkArgs` are emptied so they can't override the validated start location.

🤖 Generated with [Claude Code](https://claude.com/claude-code)